### PR TITLE
Update DEFRA adapter with two location data

### DIFF
--- a/adapters/defra.js
+++ b/adapters/defra.js
@@ -439,7 +439,7 @@ let metadata = {
    { city: 'Belfast',
      coordinates: { latitude: 54.572586, longitude: -5.974944 } },
   'Derby St Alkmund\'s Way':
-   { city: 'Bass\'s Recreation Ground St Alkmund\'s Way Derby',
+   { city: 'Derby',
      coordinates: { latitude: 52.922983, longitude: -1.469507 } },
   Derry:
    { city: 'Derry',
@@ -559,7 +559,7 @@ let metadata = {
    { city: 'Plymouth',
      coordinates: { latitude: 50.37167, longitude: -4.142361 } },
   'Plymouth Tavistock Road.':
-   { city: 'Grass Verge 104 Tavistock Road Plymouth',
+   { city: 'Plymouth',
      coordinates: { latitude: 50.411058, longitude: -4.130288 } },
   'Mace Head':
    { city: 'Mace Head',

--- a/adapters/defra.js
+++ b/adapters/defra.js
@@ -438,6 +438,9 @@ let metadata = {
   'Belfast Stockman\'s Lane':
    { city: 'Belfast',
      coordinates: { latitude: 54.572586, longitude: -5.974944 } },
+  'Derby St Alkmund\'s Way':
+   { city: 'Bass\'s Recreation Ground St Alkmund\'s Way Derby',
+     coordinates: { latitude: 52.922983, longitude: -1.469507 } },
   Derry:
    { city: 'Derry',
      coordinates: { latitude: 55.001225, longitude: -7.329115 } },
@@ -555,6 +558,9 @@ let metadata = {
   'Plymouth Centre':
    { city: 'Plymouth',
      coordinates: { latitude: 50.37167, longitude: -4.142361 } },
+  'Plymouth Tavistock Road.':
+   { city: 'Grass Verge 104 Tavistock Road Plymouth',
+     coordinates: { latitude: 50.411058, longitude: -4.130288 } },
   'Mace Head':
    { city: 'Mace Head',
      coordinates: { latitude: 53.326444, longitude: -9.903917 } },


### PR DESCRIPTION
There were several failures for the latest fetch on status.openaq.org. One of them was of DEFRA:

```
DEFRA - instance requires property "city" (2 failed)
```
I looked into `defra.js` and saw that the city and coordinates of locations were hardcoded. I did some comparison between existing UK data in API and the live source. There were 2 new locations. And some missing too.