### PR TITLE
Fix other docker-compose -p calls

### DIFF
--- a/.build_scripts/build.sh
+++ b/.build_scripts/build.sh
@@ -10,7 +10,7 @@ echo No build currently needed since we can not cache because we are on Travis l
 # fi
 
 # touch local.env
-# docker-compose --project openaq build
+# docker-compose --project-name openaq build
 
 # mkdir -p $HOME/docker
 # echo "Caching openaq_fetch docker image."

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "test": "npm run lint && mocha test/** --require babel-register",
     "start": "node index.js",
-    "docker": "docker-compose --project openaq run --rm fetch"
+    "docker": "docker-compose --project-name openaq run --rm fetch"
   },
   "author": "Joe Flasher",
   "license": "MIT",


### PR DESCRIPTION
Related: #313

Updated a couple of `docker-compose --project` commands.

`openaq-api` is using the shorthand `-p`, so that's fine.