### PR TITLE
Add feature to push measurements to S3

### DIFF
--- a/.build_scripts/ecs-task-definition.json
+++ b/.build_scripts/ecs-task-definition.json
@@ -1,5 +1,6 @@
 {
     "family": "openaq-fetch",
+    "taskRoleArn": "arn:aws:iam::470049585876:role/uploadsS3",
     "containerDefinitions": [
         {
             "name": "openaq-fetch",

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you want to push results to an S3 bucket as well for further processing, the 
 | AWS_ACCESS_KEY_ID | AWS Credentials key ID | not set |
 | AWS_SECRET_ACCESS_KEY | AWS Credentials secret key | not set |
 
-The measurements will be stored using the structure `bucket_name/fetches/yyyy-mm-dd/unixtime.csv` for each fetch.
+The measurements will be stored using the structure `bucket_name/fetches/yyyy-mm-dd/unixtime.ndjson` for each fetch.
 
 ## Tests
 To confirm that everything is working as expected, you can run the tests with

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ For production deployment, you will need to have certain environment variables s
 | EEA_TOKEN | API token for EEA API | not set |
 | EEA_GLOBAL_TIMEOUT | How long to check for EEA async results before quitting in seconds | 360 |
 | EEA_ASYNC_RECHECK | How long to wait to recheck for EEA async results in seconds | 60 |
-| PUSH_TO_S3 | Does the process push the measurements to an AWS S3 Bucket | not set |
+| SAVE_TO_S3 | Does the process save the measurements to an AWS S3 Bucket | not set |
 
 ### Pushing to AWS S3
 
-If you want to push results to an S3 bucket as well for further processing, the environment variable `PUSH_TO_S3` should be set to the value `true`. Additionally, you have to set the following environment variables:
+If you want to push results to an S3 bucket as well for further processing, the environment variable `SAVE_TO_S3` should be set to the value `true`. Additionally, you have to set the following environment variables (or be running in a process with a suitable IAM role):
 
 | Name | Description | Default |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ For production deployment, you will need to have certain environment variables s
 | EEA_TOKEN | API token for EEA API | not set |
 | EEA_GLOBAL_TIMEOUT | How long to check for EEA async results before quitting in seconds | 360 |
 | EEA_ASYNC_RECHECK | How long to wait to recheck for EEA async results in seconds | 60 |
+| PUSH_TO_S3 | Does the process push the measurements to an AWS S3 Bucket | not set |
+
+### Pushing to AWS S3
+
+If you want to push results to an S3 bucket as well for further processing, the environment variable `PUSH_TO_S3` should be set to the value `true`. Additionally, you have to set the following environment variables:
+
+| Name | Description | Default |
+|---|---|---|
+| AWS_BUCKET_NAME | AWS Bucket to store the results | not set |
+| AWS_ACCESS_KEY_ID | AWS Credentials key ID | not set |
+| AWS_SECRET_ACCESS_KEY | AWS Credentials secret key | not set |
+
+The measurements will be stored using the structure `bucket_name/fetches/yyyy-mm-dd/unixtime.csv` for each fetch.
 
 ## Tests
 To confirm that everything is working as expected, you can run the tests with

--- a/fetch.js
+++ b/fetch.js
@@ -11,7 +11,6 @@
 var argv = require('yargs')
   .usage('Usage: $0 --dryrun --source \'Beijing US Embassy\'')
   .boolean('dryrun')
-  .describe('dryrun', 'Run the fetch process but do not attempt to save to the database and instead print to console, useful for testing.')
   .alias('d', 'dryrun')
   .describe('source', 'Run the fetch process with only the defined source using source name.')
   .alias('s', 'source')
@@ -20,7 +19,7 @@ var argv = require('yargs')
   .alias('h', 'help')
   .argv;
 
-import { assign, filter, pick, chain, find } from 'lodash'; // eslint-disable-line import/first
+import { assign, filter, pick, chain, find, has } from 'lodash'; // eslint-disable-line import/first
 var async = require('async');
 var knex = require('knex');
 let knexConfig = require('./knexfile');
@@ -118,6 +117,43 @@ let buildSQLObject = function (m) {
 };
 
 /**
+ * Build a CSV row from a measurement
+ * Header: location, value, unit, parameter, country, city, sourceName, date_utc, date_local, sourceType, mobile, latitude, longitude
+ * @param {object} m measurement object
+ * @return {string} a string representing one row in a CSV
+ */
+let buildCSVObject = function (m) {
+  let row = [
+    m.location,
+    m.value,
+    m.unit,
+    m.parameter,
+    m.country,
+    m.city,
+    m.sourceName,
+    new Date(m.date.utc).toISOString(),
+    m.date.local,
+    m.sourceType,
+    m.mobile
+  ];
+  let latitude = '';
+  let longitude = '';
+
+  // Handle geo
+  if (m.coordinates) {
+    latitude = m.coordinates.latitude || '';
+    longitude = m.coordinates.longitude || '';
+  }
+  row.push(latitude);
+  row.push(longitude);
+
+  // Add double quotes to each field
+  let quotedRow = row.map(item => `"${item}"`);
+
+  return quotedRow.join(',');
+};
+
+/**
  * Create a function to ask the adapter for data, verify the data and attempt
  * to save to a database when appropriate (i.e., not running with `--dryrun`).
  * @param {object} source A source object
@@ -127,9 +163,10 @@ var getAndSaveData = function (source) {
   // Generates a formatted message based on fetch results
   let generateResultsMessage = function (newResults, source, failures, fetchStarted, fetchEnded, isDryrun = false) {
     return {
-      message: `${isDryrun ? '[Dry Run] ' : ''}New measurements inserted for ${source.name}: ${newResults}`,
+      message: `${isDryrun ? '[Dry Run] ' : ''}New measurements inserted for ${source.name}: ${newResults.length}`,
       failures: failures,
-      count: newResults,
+      count: newResults.length,
+      results: newResults,
       duration: (fetchEnded - fetchStarted) / 1000,
       sourceName: source.name
     };
@@ -139,7 +176,7 @@ var getAndSaveData = function (source) {
     // Get the appropriate adapter
     var adapter = findAdapter(source.adapter);
     if (!adapter) {
-      const msg = generateResultsMessage(0, source, {'Could not find adapter.': 1}, 0, 0, argv.dryrun);
+      const msg = generateResultsMessage([], source, {'Could not find adapter.': 1}, 0, 0, argv.dryrun);
       return done(null, msg);
     }
 
@@ -151,7 +188,7 @@ var getAndSaveData = function (source) {
         const errDict = {};
         const key = err.message || 'Unknown adapter error';
         errDict[key] = 1;
-        const msg = generateResultsMessage(0, source, errDict, fetchStarted, fetchEnded, argv.dryrun);
+        const msg = generateResultsMessage([], source, errDict, fetchStarted, fetchEnded, argv.dryrun);
         return done(null, msg);
       }
 
@@ -160,7 +197,7 @@ var getAndSaveData = function (source) {
 
       // If the data format is invalid
       if (!isValid) {
-        const msg = generateResultsMessage(0, source, reasons, fetchStarted, fetchEnded, argv.dryrun);
+        const msg = generateResultsMessage([], source, reasons, fetchStarted, fetchEnded, argv.dryrun);
         return done(null, msg);
       }
 
@@ -190,7 +227,7 @@ var getAndSaveData = function (source) {
 
       // If we have no measurements to insert, we can exit now
       if (data.measurements && data.measurements.length === 0) {
-        let msg = generateResultsMessage(data.measurements.length, source, failures, fetchStarted, fetchEnded, argv.dryrun);
+        let msg = generateResultsMessage(data.measurements, source, failures, fetchStarted, fetchEnded, argv.dryrun);
         return done(null, msg);
       }
 
@@ -198,27 +235,27 @@ var getAndSaveData = function (source) {
       if (!argv.dryrun) {
         var inserts = [];
       }
-      data.measurements.forEach((m) => {
+      data.measurements.forEach((m, index) => {
         // Save or print depending on the state
         if (argv.dryrun) {
           log.info(JSON.stringify(m));
         } else {
-          inserts.push(buildSQLObject(m));
+          inserts.push({index: index, data: buildSQLObject(m)});
         }
       });
       if (argv.dryrun) {
-        let msg = generateResultsMessage(data.measurements.length, source, failures, fetchStarted, fetchEnded, argv.dryrun);
+        let msg = generateResultsMessage(data.measurements, source, failures, fetchStarted, fetchEnded, argv.dryrun);
         done(null, msg);
       } else {
         // We're running each insert task individually so we can catch any
         // duplicate errors. Good idea? Who knows!
-        let insertRecord = function (record) {
+        let insertRecord = function (record, index) {
           return function (done) {
             pg('measurements')
               .returning('location')
               .insert(record)
               .then((loc) => {
-                done(null, {status: 'new'});
+                done(null, {status: 'new', index: index});
               })
               .catch((e) => {
                 // Log out an error if it's not an failed duplicate insert
@@ -232,7 +269,7 @@ var getAndSaveData = function (source) {
           };
         };
         let tasks = inserts.map((i) => {
-          return insertRecord(i);
+          return insertRecord(i.data, i.index);
         });
         async.parallelLimit(tasks, process.env.PSQL_POOL_MAX || 10, function (err, results) {
           if (err) {
@@ -243,7 +280,13 @@ var getAndSaveData = function (source) {
           results = filter(results, (r) => {
             return r.status !== 'duplicate';
           });
-          let msg = generateResultsMessage(results.length, source, failures, fetchStarted, fetchEnded, argv.dryrun);
+
+          // Add the original data measurement to the results
+          results = results.map(obj => {
+            return Object.assign({}, obj, {data: data.measurements[obj.index]});
+          });
+
+          let msg = generateResultsMessage(results, source, failures, fetchStarted, fetchEnded, argv.dryrun);
 
           done(null, msg);
         });
@@ -279,6 +322,59 @@ const saveFetches = function (timeStarted, timeEnded, itemsInserted, err, result
         log.error(e);
         done(null);
       });
+  };
+};
+
+/**
+ * Create a key using the current datetime
+ * @param {Date} d javascript Date() object
+ * @return {string} string in format yyyy-mm-dd/unixtime
+ */
+const getDateKey = function (d) {
+  var dd = d.getDate();
+  var mm = d.getMonth() + 1;
+  var yyyy = d.getFullYear();
+
+  if (dd < 10) {
+    dd = '0' + dd;
+  }
+
+  if (mm < 10) {
+    mm = '0' + mm;
+  }
+
+  return `${yyyy}-${mm}-${dd}/${d.getTime()}`;
+};
+
+/**
+ * Saves inserted records to S3
+ * ${param} records Array of measurements
+ *
+ */
+const saveToS3 = function (records) {
+  let AWS = require('aws-sdk');
+
+  const validAWS = has(process.env, 'AWS_BUCKET_NAME');
+
+  return function (done) {
+    if (!validAWS) {
+      return done(new Error('missing AWS Credentials'));
+    }
+
+    log.info('Saving fetch to S3');
+
+    let s3 = new AWS.S3();
+
+    // Format into CSV
+    let rows = records.map(buildCSVObject).join('\n');
+
+    // Write to an S3 bucket with the key fetches/realtime/yyyy-mm-dd/unixtime.csv
+    let date = new Date();
+    s3.putObject({
+      Bucket: process.env['AWS_BUCKET_NAME'],
+      Key: `fetches/realtime/${getDateKey(date)}.csv`,
+      Body: rows
+    }, done);
   };
 };
 
@@ -324,7 +420,8 @@ const saveSources = function () {
 var runTasks = function () {
   log.info('Running all fetch tasks.');
   let timeStarted = new Date();
-  let itemsInserted = 0;
+  let itemsInsertedCount = 0;
+  let itemsInserted = [];
   async.parallel(tasks, (err, results) => {
     let timeEnded = new Date();
     if (err) {
@@ -337,7 +434,8 @@ var runTasks = function () {
         // Add to inserted count if response has a count, if there was a failure
         // response will not have a count
         if (r.count !== undefined) {
-          itemsInserted += r.count;
+          itemsInsertedCount += r.count;
+          itemsInserted = itemsInserted.concat(r.results.map(result => result.data)); // Grab the original data measurement
         }
         log.info('///////');
         log.info(r.message);
@@ -351,13 +449,18 @@ var runTasks = function () {
     // Send out the webhook to openaq-api since we're all done
     if (argv.dryrun) {
       log.info('Dryrun completed, have a good day!');
+      console.log(itemsInserted.map(buildCSVObject));
       process.exit(0);
     } else {
       // Run functions post fetches
-      const postFetchFunctions = [
-        saveFetches(timeStarted, timeEnded, itemsInserted, err, results),
+      let postFetchFunctions = [
+        saveFetches(timeStarted, timeEnded, itemsInsertedCount, err, results),
         saveSources()
       ];
+
+      if (process.env.SAVE_TO_S3 === 'true' && itemsInsertedCount > 0) {
+        postFetchFunctions.push(saveToS3(itemsInserted));
+      }
       async.parallel(postFetchFunctions, (err, results) => {
         if (err) {
           log.error(err);

--- a/fetch.js
+++ b/fetch.js
@@ -11,6 +11,7 @@
 var argv = require('yargs')
   .usage('Usage: $0 --dryrun --source \'Beijing US Embassy\'')
   .boolean('dryrun')
+  .describe('dryrun', 'Run the fetch process but do not attempt to save to the database and instead print to console, useful for testing.')
   .alias('d', 'dryrun')
   .describe('source', 'Run the fetch process with only the defined source using source name.')
   .alias('s', 'source')

--- a/fetch.js
+++ b/fetch.js
@@ -320,7 +320,7 @@ const saveToS3 = function (records) {
     // Write to an S3 bucket with the key fetches/realtime/yyyy-mm-dd/unixtime.ndjson
     s3.putObject({
       Bucket: process.env['AWS_BUCKET_NAME'],
-      Key: `fetches/realtime/${moment().format('YYYY-MM-DD/X')}.ndjson`,
+      Key: `realtime/${moment().format('YYYY-MM-DD/X')}.ndjson`,
       Body: rows
     }, done);
   };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "adm-zip": "^0.4.7",
     "async": "^2.5",
+    "aws-sdk": "^2.92.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "buffer": "^5.0.6",


### PR DESCRIPTION
This commit allows the fetch process to push data measurements to S3
after adding them to the database.

The measurements are first added to the DB to determine if they're unique.
Unique records are then turned into CSV format and written to a user
specified AWS S3 bucket.

Pushing to S3 allows for:
1. Archiving the fetch data
2. Aggregation / Filtering in map-reduce pipelines using Amazon EMR or
Amazon Athena (could help with aggregations (#182))
