### PR TITLE
Add feature to push measurements to S3 (#354)

### DIFF
--- a/.build_scripts/ecs-task-definition.json
+++ b/.build_scripts/ecs-task-definition.json
@@ -1,5 +1,6 @@
 {
     "family": "openaq-fetch",
+    "taskRoleArn": "arn:aws:iam::470049585876:role/uploadsS3",
     "containerDefinitions": [
         {
             "name": "openaq-fetch",

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ For production deployment, you will need to have certain environment variables s
 | EEA_TOKEN | API token for EEA API | not set |
 | EEA_GLOBAL_TIMEOUT | How long to check for EEA async results before quitting in seconds | 360 |
 | EEA_ASYNC_RECHECK | How long to wait to recheck for EEA async results in seconds | 60 |
+| SAVE_TO_S3 | Does the process save the measurements to an AWS S3 Bucket | not set |
+
+### Pushing to AWS S3
+
+If you want to push results to an S3 bucket as well for further processing, the environment variable `SAVE_TO_S3` should be set to the value `true`. Additionally, you have to set the following environment variables (or be running in a process with a suitable IAM role):
+
+| Name | Description | Default |
+|---|---|---|
+| AWS_BUCKET_NAME | AWS Bucket to store the results | not set |
+| AWS_ACCESS_KEY_ID | AWS Credentials key ID | not set |
+| AWS_SECRET_ACCESS_KEY | AWS Credentials secret key | not set |
+
+The measurements will be stored using the structure `bucket_name/fetches/yyyy-mm-dd/unixtime.ndjson` for each fetch.
 
 ## Tests
 To confirm that everything is working as expected, you can run the tests with

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "adm-zip": "^0.4.7",
     "async": "^2.5",
+    "aws-sdk": "^2.92.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.3.13",
     "buffer": "^5.0.6",


### PR DESCRIPTION
* Add feature to push measurements to S3

This commit allows the fetch process to push data measurements to S3
after adding them to the database.

The measurements are first added to the DB to determine if they're unique.
Unique records are then turned into CSV format and written to a user
specified AWS S3 bucket.

Pushing to S3 allows for:
1. Archiving the fetch data
2. Aggregation / Filtering in map-reduce pipelines using Amazon EMR or
Amazon Athena (could help with aggregations (#182))

* Move from CSV to raw JSON

* Minor fixes

* Matching env var names and changing key name