### PR TITLE
Enable EEA Direct for Spain

### DIFF
--- a/sources/es.json
+++ b/sources/es.json
@@ -10,7 +10,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     },
     {
         "url": "http://www.juntadeandalucia.es/medioambiente/site/portalweb/menuitem.7e1cf46ddf59bb227a9ebe205510e1ca/?vgnextoid=7e612e07c3dc4010VgnVCM1000000624e50aRCRD&vgnextchannel=3b43de552afae310VgnVCM2000000624e50aRCRD",


### PR DESCRIPTION
This enables EEA Direct for Spain and is the second step in the roll-out plan.

This PR can be merged once it's confirmed that Andorra has good results from EEA Direct.