### PR TITLE
Enable EEA Direct for all existing sources

### DIFF
--- a/sources/at.json
+++ b/sources/at.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/be.json
+++ b/sources/be.json
@@ -11,6 +11,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/cz.json
+++ b/sources/cz.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/de.json
+++ b/sources/de.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/dk.json
+++ b/sources/dk.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/fi.json
+++ b/sources/fi.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/fr.json
+++ b/sources/fr.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/gi.json
+++ b/sources/gi.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/hr.json
+++ b/sources/hr.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/hu.json
+++ b/sources/hu.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/ie.json
+++ b/sources/ie.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]

--- a/sources/mk.json
+++ b/sources/mk.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]


### PR DESCRIPTION
This is the second attempt to fetch data from existing EEA sources. After the first attempt, fetch stopped working, which we're trying to address by reducing the amount of data the adapters try to insert (#388).

