### PR TITLE
Fix sources table format by flattening the sources output.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -185,7 +185,12 @@ export async function saveFetches ({timeStarted, timeEnded, itemsInserted, resul
  * @param {Sources} sources
  */
 export async function saveSources (sources) {
-  const inserts = Object.values(sources)
+  const inserts = Object
+    .values(sources)
+    .reduce(
+      (acc, sources) => acc.concat(sources),
+      []
+    )
     .map(data => ({data: JSON.stringify(data)}));
 
   const pg = await getDB();


### PR DESCRIPTION
Fixes #533 

@jflasher I have limitted possibility of confirming the fix, but indeed the sources are being saved in a "doubled" array. This flattens the array to a single one.