### PR TITLE
Implement error handling on stream pipelines.

### DIFF
--- a/adapters/caaqm.js
+++ b/adapters/caaqm.js
@@ -36,8 +36,16 @@ export async function fetchStream (source) {
 
   return DataStream
     .from(
-      request(options)
-        .pipe(JSONStream.parse('map.station_list.*'))
+      () => {
+        const response = request(options);
+        const parser = JSONStream.parse('map.station_list.*');
+        const output = new DataStream();
+
+        parser.on('error', (e) => output.raise(e));
+        response.on('error', (e) => output.raise(e));
+
+        return response.pipe(parser).pipe(output);
+      }
     )
     .setOptions({maxParallel: 5})
     .into(

--- a/adapters/eea-direct.js
+++ b/adapters/eea-direct.js
@@ -39,9 +39,17 @@ export async function fetchData (source, cb) {
 let _battuta = null;
 function getBattutaStream () {
   if (!_battuta) {
-    _battuta = request({url: stationsLink})
-      .pipe(JSONStream.parse('*'))
-      .pipe(new DataStream())
+    const requestObject = request({url: stationsLink});
+    _battuta = DataStream
+      .pipeline(
+        requestObject,
+        JSONStream.parse('*')
+      )
+      .catch(e => {
+        requestObject.abort();
+        e.stream.end();
+        throw e;
+      })
       .keep(Infinity);
   }
 

--- a/adapters/gios-poland.js
+++ b/adapters/gios-poland.js
@@ -19,8 +19,17 @@ export function fetchStream (source) {
   } = source;
 
   const stationUrl = `${url}/station/findAll`;
+  const requestObject = request.get(stationUrl);
   return DataStream
-    .from(() => request.get(stationUrl).pipe(JSONStream('*')))
+    .pipeline(
+      requestObject,
+      JSONStream('*')
+    )
+    .catch(e => {
+      requestObject.abort();
+      e.stream.end();
+      throw e;
+    })
     .map(
       ({
         id,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -140,9 +140,9 @@ export class MeasurementValidationError extends FetchError {
  * @param {DataStream} parent parent stream
  * @param {OpenAQEnv} env
  */
-export function forwardErrors (stream, parent, sourceObject, failures, {strict, source}) {
+export function forwardErrors (stream, parent, sourceObject, failures, {strict}) {
   return stream.catch(async (error) => {
-    if (strict || source) {
+    if (strict) {
       try { await parent.raise(error); } finally {}
     } else {
       log.verbose(`Ignoring error in "${sourceObject.name}": ${error.message}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3202,9 +3202,9 @@
       "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
     },
     "papaparse": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.6.1.tgz",
-      "integrity": "sha512-X9Ws5tnEQKRCZRfoojX3KvRZbLY1BbL0wqSHF3CKGmxD8Zr4E0WaipUuFweffkCN8RSQzHKhb/F+ATYdNcz1rg=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.6.2.tgz",
+      "integrity": "sha512-P/4p6S6wZyXAjcFPnJAjFn7lxMIkd+23prFELhcbfWswQfg7dG1XJfV8/lKvk5lu5BGSSJZFHSDMejjFcB1feg=="
     },
     "parse-filepath": {
       "version": "1.0.2",
@@ -3783,19 +3783,19 @@
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "scramjet": {
-      "version": "4.18.17",
-      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.18.17.tgz",
-      "integrity": "sha512-pH3nAHLcWZq9RlKOvgbX2kB3ihpMhUjjN9oxfUR/F/ogqSCfBEwa7GD9fx5Bc/T4Mz/XDMl3kAUndxTGBdmpbA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.19.0.tgz",
+      "integrity": "sha512-rpIfRouG9ley2bgWQOIzAa6IAGnxYrMKROaiYqD3kT4BAQKF2sqzxvUimlYSOKV5l37Utlu2/o7LdmyeHopGaQ==",
       "requires": {
-        "papaparse": "^4.6.1",
+        "papaparse": "^4.6.2",
         "rereadable-stream": "^1.2.0",
-        "scramjet-core": "^4.16.17"
+        "scramjet-core": "^4.17.0"
       }
     },
     "scramjet-core": {
-      "version": "4.16.17",
-      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.16.17.tgz",
-      "integrity": "sha512-53+WnSG7JwrXDIQSv5dmG2CBK42eURjNL5KdFWGOFkQdvOGNALe/VgYTQmPsov47nvY/jezbCg77Kuj1Hb5Apg=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.17.0.tgz",
+      "integrity": "sha512-uJyv1b4aasedULJXyEsVRpILGt+Lew1i9M3m6pGbXVVbdp61GJtIxrn2T35koVUXiIrJdmfW2NYRu7G0hAk+qg=="
     },
     "semver": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "request-promise-native": "^1.0.5",
     "require-dir": "^1.0.0",
     "s3-upload-stream": "^1.0.7",
-    "scramjet": "^4.18.17",
+    "scramjet": "^4.19.0",
     "ssl-root-cas": "^1.2.5",
     "transliteration": "^1.6.6",
     "tz-lookup": "^6.1.8",


### PR DESCRIPTION
Hi,

As mentioned in #561 here's a solution for crashes occurring in scenarios where some non-scramjet streams are being piped before piping the result into a scramjet stream. The specific case is:

    request(url) -> JSONStream(selector) -> new DataStream.

The error handling between request and JSONStream was not forwarded by default. The solution was to use a new `pipeline` method in scramjet which internally creates pipes between transform streams and forward any errors to the DataStream where it can be handled by `catch`.

The change in `caaqm` adapter may be a possible solution for #547 where similar code with `abort` could be used (which needs to be done, otherwise the unpiped response keeps the process from exiting).

@jflasher please test this on staging - to crash the adapter you can point the url in source to soemthing non-json which caused the crash in previous version.