### PR TITLE
Fix pipelining errors

### DIFF
--- a/adapters/eea-direct.js
+++ b/adapters/eea-direct.js
@@ -39,9 +39,17 @@ export async function fetchData (source, cb) {
 let _battuta = null;
 function getBattutaStream () {
   if (!_battuta) {
-    _battuta = request({url: stationsLink})
-      .pipe(JSONStream.parse('*'))
-      .pipe(new DataStream())
+    const requestObject = request({url: stationsLink});
+    _battuta = DataStream
+      .pipeline(
+        requestObject,
+        JSONStream.parse('*')
+      )
+      .catch(e => {
+        requestObject.abort();
+        e.stream.end();
+        throw e;
+      })
       .keep(Infinity);
   }
 

--- a/adapters/gios-poland.js
+++ b/adapters/gios-poland.js
@@ -19,8 +19,17 @@ export function fetchStream (source) {
   } = source;
 
   const stationUrl = `${url}/station/findAll`;
+  const requestObject = request.get(stationUrl);
   return DataStream
-    .from(() => request.get(stationUrl).pipe(JSONStream('*')))
+    .pipeline(
+      requestObject,
+      JSONStream('*')
+    )
+    .catch(e => {
+      requestObject.abort();
+      e.stream.end();
+      throw e;
+    })
     .map(
       ({
         id,

--- a/lib/db.js
+++ b/lib/db.js
@@ -117,6 +117,7 @@ function saveResultsToS3 (output, s3, bucketName, key, s3ChunkSize) {
     .catch(ignore)
     .map(({status, ...measurement}) => measurement)
     .use(streamDataToS3, s3, bucketName, key, s3ChunkSize)
+    .run()
     .catch(e => output.raise(e));
 
   const endStream = () => {
@@ -159,6 +160,8 @@ async function streamDataToS3 (stream, s3, bucketName, key, s3ChunkSize) {
       })
       .on('uploaded', resolve);
   });
+
+  return [];
 }
 
 /**

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -140,9 +140,9 @@ export class MeasurementValidationError extends FetchError {
  * @param {DataStream} parent parent stream
  * @param {OpenAQEnv} env
  */
-export function forwardErrors (stream, parent, sourceObject, failures, {strict, source}) {
+export function forwardErrors (stream, parent, sourceObject, failures, {strict}) {
   return stream.catch(async (error) => {
-    if (strict || source) {
+    if (strict) {
       try { await parent.raise(error); } finally {}
     } else {
       log.verbose(`Ignoring error in "${sourceObject.name}": ${error.message}`);
@@ -264,6 +264,7 @@ export async function cleanup () {
     try {
       log.debug(`Executing cleanup ${operation._name}`);
       await operation();
+      log.debug(`Cleanup ${operation._name} completed`);
     } catch (e) {
       log.warn(`Exception "${e.message}" occured during cleanup "${operation._name}"`);
     }


### PR DESCRIPTION
This is a retry of #573:

As mentioned in #561 here's a solution for crashes occurring in scenarios where some non-scramjet streams are being piped before piping the result into a scramjet stream. The specific case is:

    request(url) -> JSONStream(selector) -> new DataStream.

The error handling between request and JSONStream was not forwarded by default. The solution was to use a new pipeline method in scramjet which internally creates pipes between transform streams and forward any errors to the DataStream where it can be handled by catch.

The change in caaqm adapter may be a possible solution for #547 where similar code with abort could be used (which needs to be done, otherwise the unpiped response keeps the process from exiting).

As to the addition to the previous changes, a small change in returning an array from `DataStream..use` in [db.js:164](https://github.com/openaq/openaq-fetch/commit/07335d2d19a95d9d9869b8f4bca45a3f1482f78c#diff-be228df81b99a384aa50ad50bde7fca0R164) - this is due to the fact that prior to scramjet-core 4.17 the outcome of `use` was not checked as it should and the output could be anything, after a fix it's converted to a stream. The fix here is returning an empty array which results in an empty, but ended stream which in turn is converted to a promise.