### PR TITLE
CAAQM- all stations fetch url (#586)

### DIFF
--- a/sources/in.json
+++ b/sources/in.json
@@ -1,6 +1,6 @@
 [
     {
-        "url": "https://app.cpcbccr.com/caaqms/caaqms_landing_map",
+        "url": "https://app.cpcbccr.com/caaqms/caaqms_landing_map_all",
         "adapter": "caaqm",
         "name": "caaqm",
         "city": "",


### PR DESCRIPTION
the url https://app.cpcbccr.com/caaqms/caaqms_landing_map only
fetches NCR region stations, for all stations the url has to b
https://app.cpcbccr.com/caaqms/caaqms_landing_map_all