### PR TITLE
add license as a source property

### DIFF
--- a/docs/source.md
+++ b/docs/source.md
@@ -33,6 +33,7 @@ Optional properties (used to add information to measurements):
 * `city (String)` - City name
 * `location (String)` - Name of the location
 * `mobile (Boolean)` - Is the source mobile
+* `license (String` - The license for the data specified using a [SPDX identifier](https://spdx.org/licenses/).
 
 Additonally the whole object is passed to the adapter so anything can be added to the structure. Adapter usually use:
 

--- a/lib/measurement-schema.json
+++ b/lib/measurement-schema.json
@@ -29,6 +29,9 @@
                 }
             }
         },
+        "license": {
+            "type": "string"
+        },
         "attribution": {
             "type": "array",
             "items": {


### PR DESCRIPTION
I believe it's important to keep track of what license source data is provided under, so I'm proposing to add a new `license` property to the source object, using the standard SPDX identifier https://spdx.org/licenses/.