### PR TITLE
fix bug parsing NSW, Australia feed

### DIFF
--- a/adapters/nsw.js
+++ b/adapters/nsw.js
@@ -10,6 +10,18 @@ const request = baseRequest.defaults({timeout: REQUEST_TIMEOUT});
 
 export const name = 'nsw';
 
+/*
+ * There are two pages for live air quality data
+ *
+ * Index Values:
+ * https://airquality.environment.nsw.gov.au/aquisnetnswphp/getPage.php?reportid=1
+ *
+ * Data Readings:
+ * https://airquality.environment.nsw.gov.au/aquisnetnswphp/getPage.php?reportid=2
+ *
+ * This source uses the second report since it contains the raw data readings
+ * instead of index values.
+ */
 export function fetchData (source, cb) {
   request(source.url, function (err, res, body) {
     if (err || res.statusCode !== 200) {

--- a/adapters/nsw.js
+++ b/adapters/nsw.js
@@ -116,6 +116,11 @@ var formatData = function (data) {
         var regionString = $('.region', this).text();
         region = regionString || region;
 
+        // if not a region row, increment col counter to account for the missing column
+        if (!$(this).find('.region').length) {
+          colCounter++;
+        }
+
         var site = $('.site', this).text();
 
         // Store the main properties for this measuring station


### PR DESCRIPTION
closes #646, refering to the diagram from the issue, rows which didn't have a region column were incorrectly indexed resulting in values and parameters being mixed up, for example "Randwick", "Richmond" were broken but "Cook And Phillip" and "Parramatta North" were working.

cc @ReaRuiRay
