### PR TITLE
Add adapter for Icelandic data

### DIFF
--- a/adapters/ust-ist.js
+++ b/adapters/ust-ist.js
@@ -63,7 +63,7 @@ export async function fetchData (source, cb) {
 
 function parseParams (params) {
   // Array with the valid parameters in the object
-  const validParams = Object.keys(params).filter(p => acceptableParameters.includes(p.toLowerCase()));
+  const validParams = Object.keys(params).filter(p => acceptableParameters.includes(p.toLowerCase().replace('.', '')));
 
   return validParams.map(p => {
     // Assumes that '0' is always latest
@@ -81,7 +81,7 @@ function parseParams (params) {
         utc: date.toDate(), // 2020-01-03T04:00:00.000Z
         local: date.format('YYYY-MM-DDTHH:mm:ssZ') // '2020-01-03T04:00:00+00:00'
       },
-      parameter: p.toLowerCase(),
+      parameter: p.toLowerCase().replace('.', ''),
       value: Number(latestM.value),
       unit: params[p].unit,
       averagingPeriod: resolution

--- a/adapters/ust-ist.js
+++ b/adapters/ust-ist.js
@@ -1,0 +1,81 @@
+'use strict';
+
+import { default as moment } from 'moment-timezone';
+import { acceptableParameters, promiseRequest } from '../lib/utils';
+
+export const name = 'ust-ist';
+
+export async function fetchData (source, cb) {
+  try {
+    const data = JSON.parse(await promiseRequest(source.url));
+
+    // Generate an array of station ID
+    const stations = Object.keys(data);
+
+    const measurements = stations.reduce((acc, stationId) => {
+      const station = data[stationId];
+
+      // Only interested in 1 hour resolution.
+      if (station.resolution !== '1h') return acc;
+
+      const baseMeta = {
+        location: station.name,
+        city: '',
+        averagingPeriod: { value: 1, unit: 'hours' },
+        coordinates: { latitude: 0, longitude: 0 }
+      };
+
+      const latestMeasurements = parseParams(station.parameters);
+
+      return acc.concat(latestMeasurements
+        .map(m => ({ ...baseMeta, ...m }))
+      );
+    }, []);
+    cb(null, {name: 'unused', measurements});
+  } catch (e) {
+    cb(e);
+  }
+}
+
+/**
+ * Parse object with parameters, each with a series of measurements.
+ * Return an array with the latest measurement for valid parameters only.
+ *
+ * @param {object} params Parameter object
+ *
+ * @example parseParams({
+ *   'NO': [
+ *     { endtime: '2020-01-03 03:00:00', value: '0.2175', verification: 3 },
+ *     { endtime: '2020-01-03 02:00:00', value: '0.25', verification: 3 }
+ *   ],
+ *   'NO2': [
+ *     { endtime: '2020-01-03 03:00:00', value: '0.154717', verification: 3 },
+ *     { endtime: '2020-01-03 02:00:00', value: '0.13522', verification: 3 }
+ *   ]
+ * })
+ *
+ * @returns [ { value: 0.154717, date: 2020-01-03 03:00:00. parameter: 'no2' }]
+ *
+ */
+
+function parseParams (params) {
+  // Array with the valid parameters in the object
+  const validParams = Object.keys(params).filter(p => acceptableParameters.includes(p.toLowerCase()));
+
+  return validParams.map(p => {
+    // Assumes that array is always sorted
+    const latestM = params[p][0];
+
+    const date = moment.tz(latestM.endtime, 'Atlantic/Reykjavik');
+
+    return {
+      date: {
+        utc: date.toDate(), // 2020-01-03T04:00:00.000Z
+        local: date.format('YYYY-MM-DDTHH:mm:ssZ') // '2020-01-03T04:00:00+00:00'
+      },
+      parameter: p.toLowerCase(),
+      value: Number(latestM.value),
+      unit: ''
+    };
+  });
+}

--- a/adapters/ust-ist.js
+++ b/adapters/ust-ist.js
@@ -23,7 +23,11 @@ export async function fetchData (source, cb) {
         coordinates: {
           latitude: Number(stationMeta.latitude),
           longitude: Number(stationMeta.longitude)
-        }
+        },
+        attribution: [{
+          name: source.name,
+          url: source.sourceURL
+        }]
       };
       const latestMeasurements = parseParams(stationData.parameters);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,7 @@
 'use strict';
+import { REQUEST_TIMEOUT } from '../lib/constants';
+import { default as baseRequest } from 'request';
+const request = baseRequest.defaults({timeout: REQUEST_TIMEOUT});
 
 export const notEmpty = x => x;
 export const ignore = () => 0;
@@ -95,6 +98,19 @@ export async function defer (timeout = 0) {
 
 export function removeUnwantedParameters (measurements) {
   return measurements.filter(({parameter}) => acceptableParameters.includes(parameter));
+}
+
+// Promisify request
+export async function promiseRequest (url) {
+  return new Promise((resolve, reject) => {
+    request(url, (error, res, data) => {
+      if (!error && res.statusCode === 200) {
+        resolve(data);
+      } else {
+        reject(error);
+      }
+    });
+  });
 }
 
 // The platform supported parameters

--- a/sources/is.json
+++ b/sources/is.json
@@ -1,0 +1,14 @@
+[
+    {
+        "url": "https://api.ust.is/aq/a/getLatest",
+        "adapter": "ust-ist",
+        "name": "Umhverfisstofnun",
+        "country": "IS",
+        "description": "Environment Agency of Iceland",
+        "sourceURL": "https://ust.is",
+        "contacts": [
+            ""
+        ],
+        "active": true
+    }
+]

--- a/sources/is.json
+++ b/sources/is.json
@@ -1,14 +1,14 @@
 [
-    {
-        "url": "https://api.ust.is/aq/a/getLatest",
-        "adapter": "ust-ist",
-        "name": "Umhverfisstofnun",
-        "country": "IS",
-        "description": "Environment Agency of Iceland",
-        "sourceURL": "https://ust.is",
-        "contacts": [
-            ""
-        ],
-        "active": true
-    }
+  {
+    "url": "https://api.ust.is/aq/a/getLatest",
+    "adapter": "ust-ist",
+    "name": "Umhverfisstofnun",
+    "country": "IS",
+    "description": "Environment Agency of Iceland",
+    "sourceURL": "https://ust.is",
+    "contacts": [
+      "loftgaedi@umhverfisstofnun.is"
+    ],
+    "active": true
+  }
 ]


### PR DESCRIPTION
This is a first draft for an adapter to pull in the Icelandic data reported in #552. It's fairly functional, though the following is missing:

* [x] get coordinates from the stations endpoint (https://api.ust.is/aq)
* [x] add the units 
* [x] decide who the contact is
* [x] figure out what we want to do with the city property. The dry-run currently fails because city is an empty string.  
@sruti @jflasher now that the coordinates are mandatory, should we loosen the requirements on the city attribute?

