### PR TITLE
Temporarily disable GIOS Poland adapter

### DIFF
--- a/sources/pl.json
+++ b/sources/pl.json
@@ -28,6 +28,6 @@
         "sourceURL": "http://powietrze.gios.gov.pl/pjp/content/api",
         "contacts": ["info@openaq.org"],
         "hoursToFetch": 4,
-        "active": true
+        "active": false
     }
 ]


### PR DESCRIPTION
Adapter is taking 10+ minutes, causing fetch to timeout (for the past 12 hours). Disabling it until it can be fixed.