### PR TITLE
Re-enable GIOS adapter to fetch less data

### DIFF
--- a/sources/pl.json
+++ b/sources/pl.json
@@ -27,7 +27,7 @@
         "attribution": [{"name": "Portal Jakości Powietrza GIOŚ", "url": "http://powietrze.gios.gov.pl/pjp/home"}],
         "sourceURL": "http://powietrze.gios.gov.pl/pjp/content/api",
         "contacts": ["info@openaq.org"],
-        "hoursToFetch": 4,
-        "active": false
+        "hoursToFetch": 2,
+        "active": true
     }
 ]


### PR DESCRIPTION
Changing the adapter to fetch only the past 2 hours of data, instead of the past 4, reduced the the fetch time from 10+ minutes to ~30 seconds. There might be a way to optimize the adapter but it's probably not necessary since we are still capturing all the data.