### PR TITLE
Fixed arpae PM2.5 parameter to align with acceptedParameters value

### DIFF
--- a/adapters/arpae.js
+++ b/adapters/arpae.js
@@ -83,7 +83,7 @@ const parameters = {
   '21': { parameter: 'c6h5-ch3', unit: 'ug/m3' },
   '38': { parameter: 'no', unit: 'ug/m3' },
   '82': { parameter: 'o-xylene', unit: 'ug/m3' },
-  '111': { parameter: 'pm2.5', unit: 'ug/m3' }
+  '111': { parameter: 'pm25', unit: 'ug/m3' }
 };
 
 const locations = {

--- a/data_scripts/arpae-parameters.js
+++ b/data_scripts/arpae-parameters.js
@@ -19,7 +19,7 @@ request(csvUrl, (err, res, data) => {
   let parameters = {};
   parsed.forEach((el) => {
     parameters[el.IdParametro] = {
-      parameter: el.PARAMETRO.split('(')[0].toLowerCase().trim(),
+      parameter: el.PARAMETRO.split('(')[0].toLowerCase().trim().replace('.', ''),
       unit: el.UM
     };
   });


### PR DESCRIPTION
arpae-parameters.js currently parses a parameter of 'pm2.5' for PM2.5 instead of 'pm25', preventing ingestion of PM2.5 measurements from arpae adapter.