### PR TITLE
Rio adapater

### DIFF
--- a/adapters/rio.js
+++ b/adapters/rio.js
@@ -1,5 +1,6 @@
 'use strict';
 
+// TODO: fetch last month, units, sourceName, test!
 import { default as moment } from 'moment-timezone';
 import { acceptableParameters, promiseRequest } from '../lib/utils';
 
@@ -17,7 +18,7 @@ export async function fetchData(source, cb) {
 /**
  * Flatten object returned by endpoint containing array of objects,
  * each with multiple parameter measurements.
- * Return array with the latest measurement for valid parameters only. TODO: latest?
+ * Return array with the latest measurement for valid parameters only.
  *
  * @param {object} params Data object returned from endpoint
  *
@@ -46,7 +47,7 @@ export async function fetchData(source, cb) {
  *    ]
  * })
  *
- * @returns [ { TODO: test
+ * @returns [ {
     "date": { utc: 2020-01-03T04:00:00.000Z, local: YYYY-MM-DDTHH:mm:ssZ },
     "coordinates": { "latitude": -22, "longitude": -43 },
     "location": "BG",
@@ -58,7 +59,7 @@ export async function fetchData(source, cb) {
     "averagingPeriod": { "value": 1, "unit": "hours" },
     "attribution": [{ "name": "Data.rio", "url": "http://www.data.rio/" }],
     "sourceName": "x",
-    "sourceType": "research",
+    "sourceType": "government",
     "mobile": false,
   }]
  */
@@ -109,7 +110,7 @@ function parseData(measurements) {
 }
 
 function getDataObj(date, parameter, value) {
-  const unit = ["ppm", "pphm", "ppb", "ppt", "µg/m3", "mg/m3"] // TODO
+  const unit = ["ppm", "pphm", "ppb", "ppt", "µg/m3", "mg/m3"]
 
   return {
     "date": date,
@@ -122,8 +123,8 @@ function getDataObj(date, parameter, value) {
     "unit": unit,
     "averagingPeriod": { "value": 1, "unit": "hours" },
     "attribution": [{ "name": "Data.rio", "url": "http://www.data.rio/" }],
-    "sourceName": "x", // TODO: ID to track measurement to source within the platform
-    "sourceType": "research",
+    "sourceName": "",
+    "sourceType": "government",
     "mobile": false,
   }
 }

--- a/adapters/rio.js
+++ b/adapters/rio.js
@@ -2,7 +2,6 @@
 
 import { default as moment } from 'moment-timezone';
 import { acceptableParameters, promiseRequest } from '../lib/utils';
-import { parsed } from 'yargs';
 
 export const name = 'rio';
 
@@ -15,11 +14,74 @@ export async function fetchData(source, cb) {
   }
 }
 
+/**
+ * Flatten object returned by endpoint containing array of objects,
+ * each with multiple parameter measurements.
+ * Return array with the latest measurement for valid parameters only. TODO: latest?
+ *
+ * @param {object} params Data object returned from endpoint
+ *
+ * @example parseParams({
+ *    "objectIdFieldName":"OBJECTID",
+ *    "uniqueIdField": {...},
+ *    "globalIdFieldName":"",
+ *    "fields":[...],
+ *    "features":[
+ *      {"attributes":
+ *        {
+ *          "OBJECTID":1,
+ *          "Data": 1325377800000,
+ *          "Estação":"BG",
+ *          "SO2":null,
+ *          "NO2":15.18,
+ *          "CO":0.42,
+ *          "O3":28.06,
+ *          "PM10":81,
+ *          "PM2_5":null,
+ *          "Lat":-22,
+ *          "Lon":-43,
+ *        }
+ *      },
+ *      ...
+ *    ]
+ * })
+ *
+ * @returns [ { TODO: test
+    "date": { utc: 2020-01-03T04:00:00.000Z, local: YYYY-MM-DDTHH:mm:ssZ },
+    "coordinates": { "latitude": -22, "longitude": -43 },
+    "location": "BG",
+    "city": "Rio de Janeiro",
+    "country": "BR","no2"
+    "parameter": parameter,
+    "value": 15.18,
+    "unit": ppm,
+    "averagingPeriod": { "value": 1, "unit": "hours" },
+    "attribution": [{ "name": "Data.rio", "url": "http://www.data.rio/" }],
+    "sourceName": "x",
+    "sourceType": "research",
+    "mobile": false,
+  }]
+ */
 function parseData(measurements) {
   const flattened = measurements.map(m => m.attributes);
   const allData = []
 
-  flattened.forEach(m => {
+  flattened.forEach(measurement => {
+    /**
+     * @example measurement: {
+     *    "OBJECTID":1,
+     *    "Data": 1325377800000, // Date
+     *    "Estação":"BG", // Station
+     *    "SO2":null,
+     *    "NO2":15.18,
+     *    "CO":0.42,
+     *    "O3":28.06,
+     *    "PM10":81,
+     *    "PM2_5":null,
+     *    "Lat":-22.88790959,
+     *    "Lon":-43.47107415,
+     *  }
+    */
     const parsedData = [];
 
     const dateStr = moment.tz(latestM.endtime, 'Brasilia');
@@ -28,32 +90,40 @@ function parseData(measurements) {
       local: dateStr.format('YYYY-MM-DDTHH:mm:ssZ') // '2020-01-03T04:00:00+00:00'
     }
 
-    const baseDataObj = {
-      "date": date,
-      "coordinates": { "latitude": m["Lat"], "longitude": m["Lon"] },
-      "location": m["Estação"],
-      "city": "Rio de Janeiro",
-      "country": "BR",
-      "averagingPeriod": { "value": 1, "unit": "hours" },
-      "attribution": [{ "name": "Data.rio", "url": "http://www.data.rio/" }],
-      "sourceName": "x", // ID to track measurement to source within the platform
-      "sourceType": "research",
-      "mobile": false,
-    }
-
-    const validParams = Object.keys(m).filter(p => acceptableParameters.includes(p.toLowerCase().replace('_', '')));
-    validParams.each(p => {
-      if (m[p] !== null) {
-        const dataObj = JSON.parse(JSON.stringify(baseDataObj)); // Duplicate baseDataObj
-        dataObj.parameter = p;
-        dataObj.value = m[p];
-        dataObj.unit = "unit"; // TODO
-        parsed.push(dataObj);
+    // All acceptable parameters in the current measurement
+    const validParams = Object.keys(measurement).filter(
+      p => acceptableParameters.includes(p.toLowerCase().replace('_', ''))
+    );
+    validParams.each(param => {
+      const value = measurement[param];
+      if (value !== null) {
+        const datapoint = getDataObj(date, param, value)
+        parsedData.push(datapoint);
       }
     })
 
     allData.concat(parsedData);
   })
 
-  return parsed;
+  return allData;
+}
+
+function getDataObj(date, parameter, value) {
+  const unit = ["ppm", "pphm", "ppb", "ppt", "µg/m3", "mg/m3"] // TODO
+
+  return {
+    "date": date,
+    "coordinates": { "latitude": m["Lat"], "longitude": m["Lon"] },
+    "location": m["Estação"],
+    "city": "Rio de Janeiro",
+    "country": "BR",
+    "parameter": parameter,
+    "value": value,
+    "unit": unit,
+    "averagingPeriod": { "value": 1, "unit": "hours" },
+    "attribution": [{ "name": "Data.rio", "url": "http://www.data.rio/" }],
+    "sourceName": "x", // TODO: ID to track measurement to source within the platform
+    "sourceType": "research",
+    "mobile": false,
+  }
 }

--- a/adapters/rio.js
+++ b/adapters/rio.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// TODO: fetch last month, units, sourceName, test!
 import { default as moment } from 'moment-timezone';
 import { acceptableParameters, promiseRequest } from '../lib/utils';
 
@@ -28,7 +27,7 @@ export async function fetchData(source, cb) {
  *    "globalIdFieldName":"",
  *    "fields":[...],
  *    "features":[
- *      {"attributes":
+ *      { "attributes":
  *        {
  *          "OBJECTID":1,
  *          "Data": 1325377800000,
@@ -70,7 +69,6 @@ function parseData(measurements) {
   flattened.forEach(measurement => {
     /**
      * @example measurement: {
-     *    "OBJECTID":1,
      *    "Data": 1325377800000, // Date
      *    "Estação":"BG", // Station
      *    "SO2":null,
@@ -110,7 +108,10 @@ function parseData(measurements) {
 }
 
 function getDataObj(date, parameter, value) {
-  const unit = ["ppm", "pphm", "ppb", "ppt", "µg/m3", "mg/m3"]
+  let unit = "ppm";
+  if (parameter === "CO") {
+    unit = "µg/m3";
+  }
 
   return {
     "date": date,
@@ -123,7 +124,7 @@ function getDataObj(date, parameter, value) {
     "unit": unit,
     "averagingPeriod": { "value": 1, "unit": "hours" },
     "attribution": [{ "name": "Data.rio", "url": "http://www.data.rio/" }],
-    "sourceName": "",
+    "sourceName": "Prefeitura da Cidade do Rio de Janeiro – MonitorAr",
     "sourceType": "government",
     "mobile": false,
   }

--- a/adapters/rio.js
+++ b/adapters/rio.js
@@ -1,0 +1,59 @@
+'use strict';
+
+import { default as moment } from 'moment-timezone';
+import { acceptableParameters, promiseRequest } from '../lib/utils';
+import { parsed } from 'yargs';
+
+export const name = 'rio';
+
+export async function fetchData(source, cb) {
+  try {
+    const allData = JSON.parse(await promiseRequest(source.url));
+    return parseData(allData.features);
+  } catch (e) {
+    cb(e);
+  }
+}
+
+function parseData(measurements) {
+  const flattened = measurements.map(m => m.attributes);
+  const allData = []
+
+  flattened.forEach(m => {
+    const parsedData = [];
+
+    const dateStr = moment.tz(latestM.endtime, 'Brasilia');
+    const date = {
+      utc: dateStr.toDate(), // 2020-01-03T04:00:00.000Z
+      local: dateStr.format('YYYY-MM-DDTHH:mm:ssZ') // '2020-01-03T04:00:00+00:00'
+    }
+
+    const baseDataObj = {
+      "date": date,
+      "coordinates": { "latitude": m["Lat"], "longitude": m["Lon"] },
+      "location": m["Estação"],
+      "city": "Rio de Janeiro",
+      "country": "BR",
+      "averagingPeriod": { "value": 1, "unit": "hours" },
+      "attribution": [{ "name": "Data.rio", "url": "http://www.data.rio/" }],
+      "sourceName": "x", // ID to track measurement to source within the platform
+      "sourceType": "research",
+      "mobile": false,
+    }
+
+    const validParams = Object.keys(m).filter(p => acceptableParameters.includes(p.toLowerCase().replace('_', '')));
+    validParams.each(p => {
+      if (m[p] !== null) {
+        const dataObj = JSON.parse(JSON.stringify(baseDataObj)); // Duplicate baseDataObj
+        dataObj.parameter = p;
+        dataObj.value = m[p];
+        dataObj.unit = "unit"; // TODO
+        parsed.push(dataObj);
+      }
+    })
+
+    allData.concat(parsedData);
+  })
+
+  return parsed;
+}

--- a/adapters/rio.js
+++ b/adapters/rio.js
@@ -5,7 +5,7 @@ import { acceptableParameters, promiseRequest } from '../lib/utils';
 
 export const name = 'rio';
 
-export async function fetchData(source, cb) {
+export async function fetchData (source, cb) {
   try {
     const allData = JSON.parse(await promiseRequest(source.url));
     const parsedData = parseData(allData.features);
@@ -63,7 +63,7 @@ export async function fetchData(source, cb) {
   }]
  */
 
-function parseData(measurements) {
+function parseData (measurements) {
   const flattened = measurements.map(m => m.attributes);
   let allData = [];
 
@@ -87,8 +87,8 @@ function parseData(measurements) {
     const utcDate = moment.utc(measurement.Data);
     const date = {
       utc: utcDate.format(), // 2020-01-03T04:00:00.000Z
-      local: utcDate.tz("America/Sao_Paulo").format('YYYY-MM-DDTHH:mm:ssZ') // '2020-01-03T04:00:00+00:00'
-    }
+      local: utcDate.tz('America/Sao_Paulo').format('YYYY-MM-DDTHH:mm:ssZ') // '2020-01-03T04:00:00+00:00'
+    };
 
     // All acceptable parameters in the current measurement
     const validParams = Object.keys(measurement).filter(
@@ -101,29 +101,29 @@ function parseData(measurements) {
         const datapoint = getDataObj(date, measurement, param);
         parsedData.push(datapoint);
       }
-    })
+    });
 
     allData = allData.concat(parsedData);
-  })
+  });
 
   return allData;
 }
 
-function getDataObj(date, measurement, parameter) {
-  const formattedParam = parameter.toLowerCase().replace("_", "");
+function getDataObj (date, measurement, parameter) {
+  const formattedParam = parameter.toLowerCase().replace('_', '');
   return {
     date: date,
     coordinates: { latitude: measurement.Lat, longitude: measurement.Lon },
     location: measurement.Estação,
-    city: "Rio de Janeiro",
-    country: "BR",
+    city: 'Rio de Janeiro',
+    country: 'BR',
     parameter: formattedParam,
-    unit: (parameter === "CO" ? "µg/m3" : "ppm"),
+    unit: (parameter === 'CO' ? 'µg/m3' : 'ppm'),
     value: measurement[parameter],
-    averagingPeriod: { value: 1, unit: "hours" },
-    attribution: [{ name: "Data.rio", url: "http://www.data.rio/" }],
-    sourceName: "Prefeitura da Cidade do Rio de Janeiro – MonitorAr",
-    sourceType: "government",
-    mobile: false,
-  }
+    averagingPeriod: { value: 1, unit: 'hours' },
+    attribution: [{ name: 'Data.rio', url: 'http://www.data.rio/' }],
+    sourceName: 'Prefeitura da Cidade do Rio de Janeiro – MonitorAr',
+    sourceType: 'government',
+    mobile: false
+  };
 }

--- a/sources/br.json
+++ b/sources/br.json
@@ -14,7 +14,7 @@
         "active": true
     },
     {
-        "url": "https://services1.arcgis.com/OlP4dGNtIcnD3RYf/arcgis/rest/services/Qualidade_do_ar_dados_horarios_2011_2018/FeatureServer/2/query?where=Data%20%3E%20CURRENT_TIMESTAMP%20-%20INTERVAL%20%2731%27%20DAY&outFields=Data,CodNum,Esta%C3%A7%C3%A3o,SO2,NO2,CO,NO,O3,PM10,PM2_5,Lat,Lon&returnGeometry=false&outSR=4326&f=json",
+        "url": "https://services1.arcgis.com/OlP4dGNtIcnD3RYf/arcgis/rest/services/Qualidade_do_ar_dados_horarios_2011_2018/FeatureServer/2/query?where=Data%20%3E%20CURRENT_TIMESTAMP%20-%20INTERVAL%20%2731%27%20DAY&outFields=Data,CodNum,Esta%C3%A7%C3%A3o,SO2,NO2,CO,O3,PM10,PM2_5,Lat,Lon&returnGeometry=false&outSR=4326&f=json",
         "adapter": "rio",
         "name": "Rio de Janeiro",
         "city": "Rio de Janeiro",

--- a/sources/br.json
+++ b/sources/br.json
@@ -12,5 +12,18 @@
             "info@openaq.org"
         ],
         "active": true
+    },
+    {
+        "url": "https://services1.arcgis.com/OlP4dGNtIcnD3RYf/arcgis/rest/services/Qualidade_do_ar_dados_horarios_2011_2018/FeatureServer/2/query?where=1%3D1&outFields=OBJECTID,Data,CodNum,Estação,SO2,NO2,CO,PM10,PM2_5,Lat,Lon,O3&outSR=4326&f=json",
+        "adapter": "rio",
+        "name": "Rio de Janeiro",
+        "city": "Rio de Janeiro",
+        "country": "BR",
+        "description": "Data.rio",
+        "sourceURL": "http://www.data.rio/datasets/dados-hor%C3%A1rios-do-monitoramento-da-qualidade-do-ar-monitorar/geoservice?page=61045",
+            "contacts": [
+                "info@openaq.org"
+            ],
+        "active": true
     }
 ]

--- a/sources/br.json
+++ b/sources/br.json
@@ -14,7 +14,7 @@
         "active": true
     },
     {
-        "url": "https://services1.arcgis.com/OlP4dGNtIcnD3RYf/arcgis/rest/services/Qualidade_do_ar_dados_horarios_2011_2018/FeatureServer/2/query?where=1%3D1&outFields=OBJECTID,Data,CodNum,Estação,SO2,NO2,CO,PM10,PM2_5,Lat,Lon,O3&outSR=4326&f=json",
+        "url": "https://services1.arcgis.com/OlP4dGNtIcnD3RYf/arcgis/rest/services/Qualidade_do_ar_dados_horarios_2011_2018/FeatureServer/2/query?where=Data%20%3E%20CURRENT_TIMESTAMP%20-%20INTERVAL%20%2731%27%20DAY&outFields=Data,CodNum,Esta%C3%A7%C3%A3o,SO2,NO2,CO,NO,O3,PM10,PM2_5,Lat,Lon&returnGeometry=false&outSR=4326&f=json",
         "adapter": "rio",
         "name": "Rio de Janeiro",
         "city": "Rio de Janeiro",


### PR DESCRIPTION
A Rio de Janeiro adapter and source file.

- Trello ticket: https://trello.com/c/8fKDDjYw/35-add-rio-adapter
- Github issue: https://github.com/openaq/openaq-fetch/issues/500
- Data endpoint: http://www.data.rio/datasets/dados-hor%C3%A1rios-do-monitoramento-da-qualidade-do-ar-monitorar/geoservice?orderBy=Esta%C3%A7%C3%A3o
- Example data: https://services1.arcgis.com/OlP4dGNtIcnD3RYf/arcgis/rest/services/Qualidade_do_ar_dados_horarios_2011_2018/FeatureServer/2/query?where=Data%20%3E%20CURRENT_TIMESTAMP%20-%20INTERVAL%20%2731%27%20DAY&outFields=Data,CodNum,Esta%C3%A7%C3%A3o,SO2,NO2,CO,NO,O3,PM10,PM2_5,Lat,Lon&returnGeometry=false&outSR=4326&f=json