### PR TITLE
Add London Air Quality Network dataset (#792)

### DIFF
--- a/adapters/laqn.js
+++ b/adapters/laqn.js
@@ -1,0 +1,93 @@
+'use strict';
+
+import { default as moment } from 'moment-timezone';
+import _ from 'lodash';
+import log from '../lib/logger';
+import { promiseRequest, unifyParameters, unifyMeasurementUnits } from '../lib/utils';
+
+export const name = 'laqn';
+
+// API does not publish units so they are inferred from the measurement
+const unitLookup = {
+  'CO': 'µg/m3',
+  'NO2': 'µg/m3',
+  'O3': 'mg/m3',
+  'PM10': 'µg/m3',
+  'PM25': 'µg/m3',
+  'SO2': 'µg/m3'
+};
+
+export async function fetchData (source, cb) {
+  try {
+    let dateNow = moment().tz('Europe/London');
+    let startDate = dateNow.add(-1, 'days').format('DD MMM YYYY');
+    let endDate = dateNow.add(1, 'days').format('DD MMM YYYY');
+    let siteCodesResponse = await promiseRequest(
+      `${source.url}/AirQuality/Information/MonitoringSites/GroupName=All/Json`
+    );
+    let allSites = JSON.parse(siteCodesResponse).Sites.Site;
+    let siteLookup = _.keyBy(allSites, '@SiteCode');
+    let dataPromises = allSites.map((site) =>
+      promiseRequest(`${source.url}/AirQuality/Data/Site/SiteCode=${site['@SiteCode']}/StartDate=${startDate}/EndDate=${endDate}/Json`)
+        // in case a request fails, handle gracefully
+        .catch(error => { log.warn(error || `Unable to load data for site: ${site['@SiteCode']}`); return null; })
+        .then(data => formatData(data, siteLookup)));
+
+    let allData = await Promise.all(dataPromises);
+    let measurements = _.flatten(allData).filter(d => d);
+    cb(null, { name: 'unused', measurements });
+  } catch (e) {
+    cb(e);
+  }
+}
+
+// Convert data to standard format
+function formatData (data, siteLookup) {
+  if (!data) return null;
+  let dataObject = JSON.parse(data);
+  if (!_.isArray(dataObject.AirQualityData.Data)) return null;
+  let site = siteLookup[dataObject.AirQualityData['@SiteCode']];
+  const measurements = dataObject.AirQualityData.Data.map(element => {
+    let measurementDate = element['@MeasurementDateGMT'];
+    let parameter = element['@SpeciesCode'];
+    let value = element['@Value'];
+    if (!value || !parameter || !measurementDate) return null;
+    let date = moment.utc(measurementDate, 'YYYY-MM-DD HH:mm:ss');
+    let m = {
+      location: site['@SiteName'],
+      value: Number(value),
+      unit: unitLookup[parameter],
+      parameter: parameter,
+      averagingPeriod: {
+        value: 1,
+        unit: 'hours'
+      },
+      date: {
+        utc: date.toDate(),
+        local: date.format('YYYY-MM-DDTHH:mm:ssZ')
+      },
+      coordinates: {
+        latitude: Number(site['@Latitude']),
+        longitude: Number(site['@Longitude'])
+      },
+      attribution: [
+        {
+          'name': site['@DataOwner'],
+          'url': site['@SiteLink']
+        },
+        {
+          'name': site['@DataManager']
+        }
+      ],
+      city: site['@LocalAuthorityName'],
+      country: 'gb',
+      sourceName: 'London Air Quality Network',
+      sourceType: 'research',
+      mobile: false
+    };
+    m = unifyParameters(m);
+    m = unifyMeasurementUnits(m);
+    return m;
+  });
+  return measurements;
+}

--- a/adapters/laqn.js
+++ b/adapters/laqn.js
@@ -7,11 +7,11 @@ import { promiseRequest, unifyParameters, unifyMeasurementUnits } from '../lib/u
 
 export const name = 'laqn';
 
-// API does not publish units so they are inferred from the measurement
+// API does not publish units but we got them directly from the data source
 const unitLookup = {
-  'CO': 'µg/m3',
+  'CO': 'mg/m3',
   'NO2': 'µg/m3',
-  'O3': 'mg/m3',
+  'O3': 'µg/m3',
   'PM10': 'µg/m3',
   'PM25': 'µg/m3',
   'SO2': 'µg/m3'
@@ -20,7 +20,7 @@ const unitLookup = {
 export async function fetchData (source, cb) {
   try {
     let dateNow = moment().tz('Europe/London');
-    let startDate = dateNow.add(-1, 'days').format('DD MMM YYYY');
+    let startDate = dateNow.format('DD MMM YYYY');
     let endDate = dateNow.add(1, 'days').format('DD MMM YYYY');
     let siteCodesResponse = await promiseRequest(
       `${source.url}/AirQuality/Information/MonitoringSites/GroupName=All/Json`
@@ -72,17 +72,22 @@ function formatData (data, siteLookup) {
       },
       attribution: [
         {
-          'name': site['@DataOwner'],
-          'url': site['@SiteLink']
+          'name': 'Environmental Research Group of Kings College London',
+          'url': 'http://www.erg.kcl.ac.uk'
         },
         {
-          'name': site['@DataManager']
+          'name': 'London Air Quality Network',
+          'url': 'http://www.londonair.org.uk'
+        },
+        {
+          'name': site['@DataOwner'],
+          'url': site['@SiteLink']
         }
       ],
       city: site['@LocalAuthorityName'],
-      country: 'gb',
+      country: 'GB',
       sourceName: 'London Air Quality Network',
-      sourceType: 'research',
+      sourceType: 'government',
       mobile: false
     };
     m = unifyParameters(m);

--- a/sources/gb.json
+++ b/sources/gb.json
@@ -10,5 +10,15 @@
             "info@openaq.org"
         ],
         "active": true
+    },
+    {
+        "url": "http://api.erg.ic.ac.uk",
+        "adapter": "laqn",
+        "name": "London Air Quality Network",
+        "country": "GB",
+        "description": "Environmental Research Group",
+        "sourceURL": "http://api.erg.ic.ac.uk/AirQuality/Information/Documentation/pdf",
+        "contacts": ["info@openaq.org"],
+        "active": true
     }
 ]


### PR DESCRIPTION
This PR adds an laqn adapter to the gb.json source

These are the steps I followed after looking through the endpoints on http://api.erg.ic.ac.uk/AirQuality/help and reading the docs at http://api.erg.ic.ac.uk/AirQuality/Information/Documentation/pdf

1. Get all the monitoring SiteCodes from http://api.erg.ic.ac.uk/AirQuality/Information/MonitoringSites/GroupName=All/Json
2. Get the site data from https://api.erg.ic.ac.uk/AirQuality/Data/Site/SiteCode={SiteCode}/StartDate={StartDate}/EndDate={EndDate}/Json
 For each SiteCode from step 1, StartDate is like "01 Mar 2021",  EndDate is like "02 Mar 2021"
3.  Convert the hour by hour measurements that come back to the openaq measurement schema

Open questions:
- Can someone help verifying that the units I chose are correct for these measurements? (I looked through [this script](https://github.com/davidcarslaw/openair/blob/master/R/importKCL.R) for some clues)
- Do we need some kind of throttle on this `Promise.all` for fetching each site's dataset? Might depend on how this is being deployed.