### PR TITLE
Modify fetch to stop writing to DB

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -62,7 +62,7 @@ Promise.race([
       // get measurements object from given source
       // all error handling should happen inside this call
       .use(fetchCorrectedMeasurementsFromSourceStream, env)
-      // perform streamed save to DB and S3 on each source.
+      // perform streamed save to S3 on each source.
       .use(streamMeasurementsToDBAndStorage, env)
       // mark sources as finished
       .do(markSourceAs('finished', runningSources))

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,4 +1,3 @@
-import knex from 'knex';
 import moment from 'moment';
 import { pick } from 'lodash';
 import S3UploadStream from 's3-upload-stream';
@@ -7,108 +6,6 @@ import log from './logger';
 import { ignore } from './utils';
 import { cleanup } from './errors';
 
-let _pg = null;
-function getDB () {
-  let knexConfig;
-  _pg = _pg || (async () => {
-    try {
-      knexConfig = require('../knexfile-local');
-      log.info('Using connection data from knexfile-local');
-    } catch (e) {
-      knexConfig = require('../knexfile');
-      log.info('Using connection data from production knexfile');
-    }
-
-    const pg = knex(knexConfig);
-    log.info('Connecting to database.');
-
-    return pg;
-  })()
-    .then(async pg => {
-      await pg.migrate.latest(knexConfig);
-      log.info('Database connected and migrations are handled, ready to roll!');
-      return pg;
-    });
-  // Run any needed migrations and away we go
-  return _pg;
-}
-
-/**
- * Build an object that can be inserted into our database.
- * @param {object} m measurement object
- * @return {object} an object capable of being saved into the PostgreSQL database
- */
-function convertMeasurementToSQLObject (measurement, st, pg) {
-  const obj = {
-    location: measurement.location,
-    value: measurement.value,
-    unit: measurement.unit,
-    parameter: measurement.parameter,
-    country: measurement.country,
-    city: measurement.city,
-    source_name: measurement.sourceName,
-    date_utc: measurement.date.utc,
-    source_type: measurement.sourceType,
-    mobile: measurement.mobile
-  };
-
-  // Copy object JSON to the cause field
-  obj.data = Object.assign({}, measurement);
-
-  // If we have coordinates, save them with postgis
-  if (measurement.coordinates) {
-    obj.coordinates = st.geomFromText(`Point(${measurement.coordinates.longitude} ${measurement.coordinates.latitude})`, 4326);
-  }
-
-  return obj;
-}
-
-function streamRecordsToPg (stream, pg) {
-  const st = require('knex-postgis')(pg);
-
-  const table = pg('measurements')
-    .returning('location');
-
-  return stream
-    .tap()
-    .pipe(new DataStream())
-    .setOptions({maxParallel: 1})
-    .assign(async measurement => {
-      const record = convertMeasurementToSQLObject(measurement, st, pg);
-      try {
-        await table.insert(record);
-      } catch (cause) {
-        if (cause.code === '23505') {
-          return { status: 'duplicate' };
-        }
-
-        throw cause;
-      }
-      return { status: 'inserted' };
-    });
-}
-
-/**
- * Streams measurements to database and retuns stream of only the inserted items.
- *
- * @param {DataStream} stream
- * @param {Knex} pg
- * @param {Object} counts
- */
-function streamDataToDB (stream, pg, counts) {
-  return stream
-    .use(streamRecordsToPg, pg)
-    .filter(({status}) => {
-      if (status === 'duplicate') {
-        counts.duplicates++;
-        return false;
-      }
-
-      counts.inserted++;
-      return true;
-    })
-  ;
-}
 
 function saveResultsToS3 (output, s3, bucketName, key, s3ChunkSize) {
   const stream = new DataStream();
@@ -170,17 +67,17 @@ async function streamDataToS3 (stream, s3, bucketName, key, s3ChunkSize) {
  * @param {FetchResult} sources
  */
 export async function saveFetches ({timeStarted, timeEnded, itemsInserted, results}) {
-  const pg = await getDB();
+  // const pg = await getDB();
 
-  return pg('fetches')
-    .insert([{
-      time_started: new Date(timeStarted),
-      time_ended: new Date(timeEnded),
-      count: itemsInserted,
-      results: JSON.stringify(results)
-    }])
-    .then(() => log.info('Fetches table successfully updated'))
-    .catch((error) => log.error(error));
+  // return pg('fetches')
+  //   .insert([{
+  //     time_started: new Date(timeStarted),
+  //     time_ended: new Date(timeEnded),
+  //     count: itemsInserted,
+  //     results: JSON.stringify(results)
+  //   }])
+  //   .then(() => log.info('Fetches table successfully updated'))
+  //   .catch((error) => log.error(error));
 }
 
 /**
@@ -195,13 +92,13 @@ export async function saveSources (sources) {
     .map(data => (pick(data, ['url', 'adapter', 'name', 'city', 'country', 'description', 'sourceURL', 'resolution', 'contacts', 'active'])))
     .map(data => ({data: JSON.stringify(data)}));
 
-  const pg = await getDB();
-  return pg('sources')
-    .del()
-    .then(() => log.verbose('Sources table successfully deleted.'))
-    .then(() => pg('sources').insert(inserts))
-    .then(() => log.info('Sources table successfully updated.'))
-    .catch((e) => log.error(e));
+  // const pg = await getDB();
+  // return pg('sources')
+  //   .del()
+  //   .then(() => log.verbose('Sources table successfully deleted.'))
+  //   .then(() => pg('sources').insert(inserts))
+  //   .then(() => log.info('Sources table successfully updated.'))
+  //   .catch((e) => log.error(e));
 }
 
 /**
@@ -222,17 +119,14 @@ export function streamMeasurementsToDBAndStorage (sourcesStream, {doSaveToS3, s3
 
     let s3stream = null;
     if (doSaveToS3) {
-      const key = `realtime/${moment().format('YYYY-MM-DD/X')}.ndjson`;
+      const key = `test-realtime/${moment().format('YYYY-MM-DD/X')}.ndjson`;
       s3stream = saveResultsToS3(output, new (require('aws-sdk').S3)(), bucketName, key, s3ChunkSize);
     }
 
     sourcesStream
       .map(async (item) => {
-        const pg = await getDB();
         const { stream: measurementStream, counts } = item;
-
-        const stream = measurementStream.use(streamDataToDB, pg, counts);
-        await (doSaveToS3 ? s3stream.pull(stream) : stream.run());
+        await (doSaveToS3 ? s3stream.pull(measurementStream) : measurementStream.run());
 
         return item;
       })

--- a/lib/db.js
+++ b/lib/db.js
@@ -77,7 +77,7 @@ export function streamMeasurementsToDBAndStorage (sourcesStream, {doSaveToS3, s3
 
     let s3stream = null;
     if (doSaveToS3) {
-      const key = `test-realtime/${moment().format('YYYY-MM-DD/X')}.ndjson`;
+      const key = `realtime/${moment().format('YYYY-MM-DD/X')}.ndjson`;
       s3stream = saveResultsToS3(output, new (require('aws-sdk').S3)(), bucketName, key, s3ChunkSize);
     }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,11 +1,9 @@
 import moment from 'moment';
-import { pick } from 'lodash';
 import S3UploadStream from 's3-upload-stream';
 import { DataStream } from 'scramjet';
 import log from './logger';
 import { ignore } from './utils';
 import { cleanup } from './errors';
-
 
 function saveResultsToS3 (output, s3, bucketName, key, s3ChunkSize) {
   const stream = new DataStream();
@@ -62,46 +60,6 @@ async function streamDataToS3 (stream, s3, bucketName, key, s3ChunkSize) {
 }
 
 /**
- * Saves information about fetches to the database
- *
- * @param {FetchResult} sources
- */
-export async function saveFetches ({timeStarted, timeEnded, itemsInserted, results}) {
-  // const pg = await getDB();
-
-  // return pg('fetches')
-  //   .insert([{
-  //     time_started: new Date(timeStarted),
-  //     time_ended: new Date(timeEnded),
-  //     count: itemsInserted,
-  //     results: JSON.stringify(results)
-  //   }])
-  //   .then(() => log.info('Fetches table successfully updated'))
-  //   .catch((error) => log.error(error));
-}
-
-/**
- * Save sources information, overwritten any previous results
- *
- * @param {Sources} sources
- */
-export async function saveSources (sources) {
-  const inserts = Object.values(sources)
-    .reduce((acc, sources) => acc.concat(sources), [])
-    .filter(data => (data.adapter !== 'dummy'))
-    .map(data => (pick(data, ['url', 'adapter', 'name', 'city', 'country', 'description', 'sourceURL', 'resolution', 'contacts', 'active'])))
-    .map(data => ({data: JSON.stringify(data)}));
-
-  // const pg = await getDB();
-  // return pg('sources')
-  //   .del()
-  //   .then(() => log.verbose('Sources table successfully deleted.'))
-  //   .then(() => pg('sources').insert(inserts))
-  //   .then(() => log.info('Sources table successfully updated.'))
-  //   .catch((e) => log.error(e));
-}
-
-/**
  * Streams measurements to database and cloud storage
  *
  * @param {OpenAQEnv} env
@@ -125,7 +83,7 @@ export function streamMeasurementsToDBAndStorage (sourcesStream, {doSaveToS3, s3
 
     sourcesStream
       .map(async (item) => {
-        const { stream: measurementStream, counts } = item;
+        const { stream: measurementStream } = item;
         await (doSaveToS3 ? s3stream.pull(measurementStream) : measurementStream.run());
 
         return item;

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -1,7 +1,6 @@
 import request from 'request';
 import log from './logger';
 import { promisify } from 'util';
-import { saveFetches, saveSources } from './db';
 
 /**
 * Ping openaq-api to let it know cause fetching is complete
@@ -41,10 +40,6 @@ export function reportAndRecordFetch (fetchReport, sources, argv, apiURL, webhoo
       return 0;
     }
 
-    await Promise.all([
-      saveFetches(fetchReport),
-      saveSources(sources)
-    ]);
     await sendUpdatedWebhook(apiURL, webhookKey);
     log.info('Webhook posted, have a good day!');
     return 0;


### PR DESCRIPTION
With the new DB, ingest happens directly from S3 into the DB via a lambda function. This means fetch no longer has to write to the DB.

Note: I left in the code to post to the webhook (although that doesn't do anything currently) because I'll be revisiting the webhook -> fetches table -> fetches API -> fluffy/status/etc flow in a future improvement