### PR TITLE
Update dev-quick-start to match defaults in env.js for first time setup

### DIFF
--- a/docs/dev-quick-start.md
+++ b/docs/dev-quick-start.md
@@ -24,9 +24,9 @@ Follow these steps to create a full local development environment (this is proba
 4. Install dependencies `cd openaq-fetch && npm install`
 5. Create a user and db in postgres in `docker exec -ti postgis psql -U postgres`
 ```sql
-CREATE ROLE openaq WITH LOGIN PASSWORD 'openaq-password';
-CREATE DATABASE openaq OWNER openaq;
-\connect openaq
+CREATE ROLE openaq WITH LOGIN PASSWORD 'openaq-pass';
+CREATE DATABASE "openaq-local" OWNER openaq;
+\connect "openaq-local"
 CREATE EXTENSION postgis;
 \quit
 ```


### PR DESCRIPTION
the defaults in [env.js](https://github.com/openaq/openaq-fetch/blob/develop/lib/env.js) looks like this:

```js
  const psqlPassword = _env.PSQL_PASSWORD || 'openaq-pass';
  const psqlDatabase = _env.PSQL_DATABASE || 'openaq-local';
```

`openaq-pass` vs `openaq-password`
and
`openaq-local` vs `openaq`

This was a snag I hit following the setup guide for the first time.
Once I got them aligned i was able to get everything running.