### PR TITLE
replaced deprecated libraries laqn.js

### DIFF
--- a/src/adapters/laqn.js
+++ b/src/adapters/laqn.js
@@ -1,46 +1,59 @@
 'use strict';
 
-import { default as moment } from 'moment-timezone';
 import _ from 'lodash';
 import log from '../lib/logger.js';
-import { promiseRequest, unifyParameters, unifyMeasurementUnits } from '../lib/utils.js';
+import { DateTime } from 'luxon';
+import {
+  promiseRequest,
+  unifyParameters,
+  unifyMeasurementUnits,
+} from '../lib/utils.js';
 
 export const name = 'laqn';
 
 // API does not publish units but we got them directly from the data source
 const unitLookup = {
-  'CO': 'mg/m3',
-  'NO2': 'µg/m3',
-  'O3': 'µg/m3',
-  'PM10': 'µg/m3',
-  'PM25': 'µg/m3',
-  'SO2': 'µg/m3'
+  CO: 'mg/m3',
+  NO2: 'µg/m3',
+  O3: 'µg/m3',
+  PM10: 'µg/m3',
+  PM25: 'µg/m3',
+  SO2: 'µg/m3',
 };
 
-export async function fetchData (source, cb) {
+export async function fetchData(source, cb) {
   try {
+    const timeZone = 'Europe/London';
+    const dateNow = source.datetime
+      ? DateTime.fromISO(source.datetime, { zone: timeZone }) // WHAT FORMAT IS source.datetime ??? "YYYY-MM-DD HH:mm:ss" eg "2022-04-27 06:03:26" ???
+      : DateTime.now().setZone(timeZone);
 
-    let dateNow = source.datetime
-        ? moment(source.datetime).tz('Europe/London')
-        : moment().tz('Europe/London');
+    const startDate = dateNow.toFormat('dd LLL yyyy');
+    const endDate = dateNow.plus({ days: 1 }).toFormat('dd LLL yyyy');
 
-    let startDate = dateNow.format('DD MMM YYYY');
-    let endDate = dateNow.add(1, 'days').format('DD MMM YYYY');
-
-    let siteCodesResponse = await promiseRequest(
+    const siteCodesResponse = await promiseRequest(
       `${source.url}/AirQuality/Information/MonitoringSites/GroupName=All/Json`
     );
     let allSites = JSON.parse(siteCodesResponse).Sites.Site;
     // assuming these are all marked once they are closed
-    allSites = allSites.filter(s => !s['@DateClosed']);
-    let siteLookup = _.keyBy(allSites, '@SiteCode');
-    let dataPromises = allSites.map((site) =>
-      promiseRequest(`${source.url}/AirQuality/Data/Site/SiteCode=${site['@SiteCode']}/StartDate=${startDate}/EndDate=${endDate}/Json`)
-        .catch(error => { log.warn(error || `Unable to load data for site: ${site['@SiteCode']}`); return null; })
-        .then(data => formatData(data, siteLookup)));
+    allSites = allSites.filter((s) => !s['@DateClosed']);
+    const siteLookup = _.keyBy(allSites, '@SiteCode');
+    const dataPromises = allSites.map((site) =>
+      promiseRequest(
+        `${source.url}/AirQuality/Data/Site/SiteCode=${site['@SiteCode']}/StartDate=${startDate}/EndDate=${endDate}/Json`
+      )
+        .catch((error) => {
+          log.warn(
+            error ||
+              `Unable to load data for site: ${site['@SiteCode']}`
+          );
+          return null;
+        })
+        .then((data) => formatData(data, siteLookup))
+    );
 
-    let allData = await Promise.all(dataPromises);
-    let measurements = _.flatten(allData).filter(d => d);
+    const allData = await Promise.all(dataPromises);
+    const measurements = _.flatten(allData).filter((d) => d);
     cb(null, { name: 'unused', measurements });
   } catch (e) {
     cb(e);
@@ -50,55 +63,62 @@ export async function fetchData (source, cb) {
 // Convert data to standard format
 function formatData (data, siteLookup) {
   if (!data) return null;
-  let dataObject = JSON.parse(data);
+  const dataObject = JSON.parse(data);
   if (!_.isArray(dataObject.AirQualityData.Data)) return null;
-  let site = siteLookup[dataObject.AirQualityData['@SiteCode']];
-  const measurements = dataObject.AirQualityData.Data.map(element => {
-    let measurementDate = element['@MeasurementDateGMT'];
-    let parameter = element['@SpeciesCode'];
-    let value = element['@Value'];
-    if (!value || !parameter || !measurementDate) return null;
-    let date = moment.utc(measurementDate, 'YYYY-MM-DD HH:mm:ss');
-    let m = {
-      location: site['@SiteName'],
-      value: Number(value),
-      unit: unitLookup[parameter],
-      parameter: parameter,
-      averagingPeriod: {
-        value: 1,
-        unit: 'hours'
-      },
-      date: {
-        utc: date.toDate(),
-        local: date.format('YYYY-MM-DDTHH:mm:ssZ')
-      },
-      coordinates: {
-        latitude: Number(site['@Latitude']),
-        longitude: Number(site['@Longitude'])
-      },
-      attribution: [
-        {
-          'name': 'Environmental Research Group of Imperial College London',
-          'url': 'https://www.imperial.ac.uk/school-public-health/environmental-research-group/'
+  const site = siteLookup[dataObject.AirQualityData['@SiteCode']];
+  const measurements = dataObject.AirQualityData.Data.map(
+    (element) => {
+      const measurementDate = element['@MeasurementDateGMT'];
+      const parameter = element['@SpeciesCode'];
+      const value = element['@Value'];
+      if (!value || !parameter || !measurementDate) return null;
+      const format = 'yyyy-MM-dd HH:mm:ss';
+      const date = DateTime.fromFormat(measurementDate, format, {
+        zone: 'utc',
+      });
+      let m = {
+        location: site['@SiteName'],
+        value: parseFloat(value),
+        unit: unitLookup[parameter],
+        parameter: parameter,
+        averagingPeriod: {
+          value: 1,
+          unit: 'hours',
         },
-        {
-          'name': 'London Air Quality Network',
-          'url': 'https://www.londonair.org.uk'
+        date: {
+          utc: date.toISO({ suppressMilliseconds: true }),
+          local: date
+            .setZone('Europe/London')
+            .toISO({ suppressMilliseconds: true }),
         },
-        {
-          'name': site['@DataOwner'],
-          'url': site['@SiteLink']
-        }
-      ],
-      city: site['@LocalAuthorityName'],
-      country: 'GB',
-      sourceName: 'London Air Quality Network',
-      sourceType: 'government',
-      mobile: false
-    };
-    m = unifyParameters(m);
-    m = unifyMeasurementUnits(m);
-    return m;
-  });
+        coordinates: {
+          latitude: parseFloat(site['@Latitude']),
+          longitude: parseFloat(site['@Longitude']),
+        },
+        attribution: [
+          {
+            name: 'Environmental Research Group of Imperial College London',
+            url: 'https://www.imperial.ac.uk/school-public-health/environmental-research-group/',
+          },
+          {
+            name: 'London Air Quality Network',
+            url: 'https://www.londonair.org.uk',
+          },
+          {
+            name: site['@DataOwner'],
+            url: site['@SiteLink'],
+          },
+        ],
+        city: site['@LocalAuthorityName'],
+        country: 'GB',
+        sourceName: 'London Air Quality Network',
+        sourceType: 'government',
+        mobile: false,
+      };
+      m = unifyParameters(m);
+      m = unifyMeasurementUnits(m);
+      return m;
+    }
+  );
   return measurements;
 }


### PR DESCRIPTION
updated:
- `moment` -> `luxon`
- `request` -> `got`
I need to be sure the format of `source.datetime` before we pull this one in... would it be the format of `datetime` referenced in [index.js](https://github.com/openaq/openaq-fetch/blob/6c09adbbe0ec695e8a3f924a0645ee65af0b64cf/src/index.js#L11)?