### PR TITLE
Khartoum Residential active: false. Duplicate of airnow

### DIFF
--- a/src/sources/sd.json
+++ b/src/sources/sd.json
@@ -23,6 +23,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]


### PR DESCRIPTION
Every measurement of this adapter is the same location, and a duplicate of AirNow data. Setting to active: false
closes #1009 