### PR TITLE
handles datetime logic to deal with 1-24hr time

### DIFF
--- a/src/adapters/japan.js
+++ b/src/adapters/japan.js
@@ -109,8 +109,10 @@ async function getAirQualityData (jpDataUrl) {
         );
 
         const result = data.flatMap((row) => {
-          const dateTimeStr = `${row['年']}-${row['月']}-${row['日']}T${row['時']}:00:00`;
-          const jstTime = DateTime.fromISO(dateTimeStr, { zone: 'Asia/Tokyo' });
+          const hour = parseInt(row['時']) - 1;
+          const dateTimeStr = `${row['年']}-${row['月']}-${row['日']}T${String(hour).padStart(2, '0')}:59:00`;
+          let jstTime = DateTime.fromISO(dateTimeStr, { zone: 'Asia/Tokyo' });
+          jstTime = jstTime.plus({ minutes: 1 });
 
           return Object.entries(units)
             .filter(


### PR DESCRIPTION
closes #1056

Japan source reports hours as 1-24. This was handled by subtracting a minute from the incoming row data, and then add the minute back in after the luxon datetime object is created. This avoids having to deal with month and leap year logic problems that would occur as a result of manually changing the hours from 1-24hrs to 0-23hrs.