### PR TITLE
Set sources inactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes to adapters will be documented in this file.
 - south-australia-epa (needs environment variables)
 - Australia - Victoria (needs environment variables)
 - Australia - New South Wales (needs environment variables)
+- Trinidad & Tobago ( needs fix )
 
 ## 07/13/2023
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Changes to adapters will be documented in this file.
 
+## 08/23/2023
+### Set active: false
+- all China stateair adapters (stateair.net not resolving)
+- Brazil CETESB (needs environment variables)
+- south-australia-epa (needs environment variables)
+- Australia - Victoria (needs environment variables)
+- Australia - New South Wales (needs environment variables)
+
 ## 07/13/2023
 ### Removed
 - src/adapters/moscow.js

--- a/src/sources/au.json
+++ b/src/sources/au.json
@@ -12,7 +12,7 @@
             "info@openaq.org",
             "olaf@developmentseed.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "https://apps.des.qld.gov.au/air-quality/xml/feed.php?category=1&region=ALL",
@@ -82,6 +82,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/br.json
+++ b/src/sources/br.json
@@ -11,7 +11,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "https://jeap.rio.rj.gov.br/je-metinfosmac/portalV2/estacao",

--- a/src/sources/cn.json
+++ b/src/sources/cn.json
@@ -11,7 +11,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "http://www.stateair.net/web/rss/1/2.xml",
@@ -25,7 +25,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "http://www.stateair.net/web/rss/1/3.xml",
@@ -39,7 +39,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "http://www.stateair.net/web/rss/1/4.xml",
@@ -53,7 +53,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "http://www.stateair.net/web/rss/1/5.xml",
@@ -67,7 +67,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "s3://openaq-chinaaqidata/airnow.json",

--- a/src/sources/tt.json
+++ b/src/sources/tt.json
@@ -9,6 +9,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]


### PR DESCRIPTION
`stateair.net` is causing the lambda to timeout before all the fetch adapters finish. other sources are having issues that need to be resolved

#### Set active: false
- all China stateair adapters (stateair.net not resolving)
- Brazil CETESB (needs environment variables)
- south-australia-epa (needs environment variables)
- Australia - Victoria (needs environment variables)
- Australia - New South Wales (needs environment variables)
- Trinidad & Tobago ( needs fix )