### PR TITLE
Update Node version to 18

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "14"
+          node-version: "18"
 
       - name: Install CDK
         run: |

--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -58,7 +58,7 @@ export class RealtimeFetcherStack extends cdk.Stack {
         code: lambda.Code.fromAsset('../src'),
         handler: 'scheduler.handler',
         memorySize: 128,
-        runtime: lambda.Runtime.NODEJS_14_X,
+        runtime: lambda.Runtime.NODEJS_18_X,
         timeout: cdk.Duration.seconds(30),
         environment: env,
       }

--- a/cdk/stack.ts
+++ b/cdk/stack.ts
@@ -72,7 +72,7 @@ export class RealtimeFetcherStack extends cdk.Stack {
         code: lambda.Code.fromAsset('../src'),
         handler: 'fetch.handler',
         memorySize: 1024,
-        runtime: lambda.Runtime.NODEJS_14_X,
+        runtime: lambda.Runtime.NODEJS_18_X,
         timeout: cdk.Duration.seconds(900),
         environment: env,
       }


### PR DESCRIPTION
I have tested running all of the adapters several times after updating fromNode 14 to Node 18. I think we can deploy this safely, I will be sure to keep an eye on it.