### PR TITLE
Switch off stale adapters

### DIFF
--- a/src/deployments.js
+++ b/src/deployments.js
@@ -16,11 +16,12 @@ const deploymentsArray = [
     source: 'London Air Quality Network'
   },
   // The eea provider has a lag and so we need to use the offset
-  {
-    name: 'eea',
-    adapter: 'eea-direct',
-    offset: 24
-  },
+  // old eea adapter, data URL is walled with permission requirements
+  // {
+  //   name: 'eea',
+  //   adapter: 'eea-direct',
+  //   offset: 24
+  // },
   // one of ACUMAR's stations is always late
   {
     name: 'acumar',

--- a/src/sources/ad.json
+++ b/src/sources/ad.json
@@ -12,6 +12,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/at.json
+++ b/src/sources/at.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/ba.json
+++ b/src/sources/ba.json
@@ -33,7 +33,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "http://dosairnowdata.org/dos/RSS/Sarajevo/Sarajevo-PM2.5.xml",

--- a/src/sources/be.json
+++ b/src/sources/be.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/bg.json
+++ b/src/sources/bg.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/ch.json
+++ b/src/sources/ch.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/cy.json
+++ b/src/sources/cy.json
@@ -10,7 +10,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "https://www.airquality.dli.mlsi.gov.cy/all_stations_data_PM",

--- a/src/sources/cz.json
+++ b/src/sources/cz.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/de.json
+++ b/src/sources/de.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/dk.json
+++ b/src/sources/dk.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/es.json
+++ b/src/sources/es.json
@@ -10,7 +10,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "http://www.juntadeandalucia.es/medioambiente/site/portalweb/menuitem.7e1cf46ddf59bb227a9ebe205510e1ca/?vgnextoid=7e612e07c3dc4010VgnVCM1000000624e50aRCRD&vgnextchannel=3b43de552afae310VgnVCM2000000624e50aRCRD",

--- a/src/sources/fi.json
+++ b/src/sources/fi.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/fr.json
+++ b/src/sources/fr.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/ge.json
+++ b/src/sources/ge.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/gi.json
+++ b/src/sources/gi.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/gr.json
+++ b/src/sources/gr.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/hr.json
+++ b/src/sources/hr.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/hu.json
+++ b/src/sources/hu.json
@@ -10,7 +10,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "https://legszennyezettseg.met.hu/api/terkep/",

--- a/src/sources/ie.json
+++ b/src/sources/ie.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/it.json
+++ b/src/sources/it.json
@@ -93,6 +93,6 @@
     "contacts": [
       "info@openaq.org"
     ],
-    "active": true
+    "active": false
   }
 ]

--- a/src/sources/lt.json
+++ b/src/sources/lt.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/lu.json
+++ b/src/sources/lu.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/lv.json
+++ b/src/sources/lv.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/me.json
+++ b/src/sources/me.json
@@ -9,6 +9,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/mk.json
+++ b/src/sources/mk.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/mt.json
+++ b/src/sources/mt.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/pt.json
+++ b/src/sources/pt.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/ro.json
+++ b/src/sources/ro.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/rs.json
+++ b/src/sources/rs.json
@@ -10,7 +10,7 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     },
     {
         "url": "http://www.amskv.sepa.gov.rs/konektori/get_json_connector_stations_map.php",

--- a/src/sources/se.json
+++ b/src/sources/se.json
@@ -24,6 +24,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/sk.json
+++ b/src/sources/sk.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": true
+        "active": false
     }
 ]

--- a/src/sources/za.json
+++ b/src/sources/za.json
@@ -25,6 +25,6 @@
     "contacts": [
         "info@openaq.org"
     ],
-    "active": true
+    "active": false
   }
 ]


### PR DESCRIPTION
Set `active:false` all `eea-direct` adapters and `South Africa`, `Bosnia_Tuzlanski`, and `Montenegro` adapters. 

South Africa, Bosnia_Tuzlanski, and Montenegro, need investigation and updates to their adapters

EEA adapter is likely to be deprecated in favor of a new adapter that is currently being tested.