### PR TITLE
Update time zone in South Korea adapter

### DIFF
--- a/src/adapters/southkorea.js
+++ b/src/adapters/southkorea.js
@@ -96,7 +96,7 @@ function formatData(station, paramCode) {
     );
 
     return {
-        location: station.STATION_ADDR,
+        location: station.STATION_NAME,
         city: '',
         coordinates: {
             latitude: parseFloat(station.DM_Y),

--- a/src/adapters/southkorea.js
+++ b/src/adapters/southkorea.js
@@ -1,6 +1,5 @@
 import Bottleneck from 'bottleneck';
 import { DateTime } from 'luxon';
-import { load } from 'cheerio';
 
 import { FetchError, DATA_URL_ERROR } from '../lib/errors.js';
 import client from '../lib/requests.js';
@@ -9,7 +8,6 @@ import log from '../lib/logger.js';
 // maximum number of concurrent requests to make to the API.
 const maxConcurrent = 32;
 
-const baseUrl = 'https://www.airkorea.or.kr/eng/vicinityStation';
 const stationsUrl = 'https://www.airkorea.or.kr/web/mRealAirInfoAjax';
 
 const paramCodes = {
@@ -52,51 +50,11 @@ export async function fetchData(source, cb) {
  */
 async function fetchDataByCode(paramCode) {
     const stations = await fetchStations(paramCode);
-    const wrappedfetchMeasurments = limiter.wrap(fetchMeasurments.bind(null, paramCode));
-    const formattedStations = await Promise.all(
-        stations
-        // .slice(0,5) // for testing
-        .map(async (station) => {
-            const detailedStation = await wrappedfetchMeasurments(station);
-            return formatData(detailedStation, paramCode);
-        })
-    );
-    const filteredStations = formattedStations.filter(station => station.value !== null);
-    return filteredStations;
-}
-
-/**
- * This fetches HTML to get the measurement value. URLs are constructed with the station code and the parameter code.
- * @param {number} paramCode - The parameter code for the pollutant being measured.
- * @param {Object} station - An object representing a station, including its code.
- * @returns {Promise<Object>} - A promise that resolves to an object containing the original station
- *                              information along with the measured value of the pollutant.
- */
-async function fetchMeasurments(paramCode, station) {
-
-    const params = {
-        item_code: paramCode,
-        station_code: station.STATION_CODE
-    };
-
-    try {
-        const body = await client({ url: baseUrl, params, responseType: 'text' });
-
-        const $ = load(body);
-        const concentrationText = $('tr.al2')
-              .filter(function () {
-                  return $(this).find('th').text().trim() === 'concentration';
-              })
-              .find('td')
-              .text()
-              .trim();
-        const measurementValue = parseFloat(concentrationText.split(' ')[0]);
-
-        return { ...station, measurementValue };
-    } catch (error) {
-        log.error('Error fetching details for station:', station.STATION_CODE, error.message);
-        return station;
-    }
+    const formattedStations = stations
+        // .slice(0, 10) // for testing
+        .map(station => formatData(station, paramCode))
+        .filter(station => station.value !== null);
+    return formattedStations;
 }
 
 /**
@@ -149,7 +107,7 @@ function formatData(station, paramCode) {
             utc: dateTime.toUTC().toISO({suppressMilliseconds: true}),
             local: dateTime.toISO({suppressMilliseconds: true}),
         },
-        value: station.measurementValue,
+        value: parseFloat(station.VALUE),
         unit: paramCodes[paramCode].unit,
         attribution: [
             {

--- a/src/adapters/southkorea.js
+++ b/src/adapters/southkorea.js
@@ -55,7 +55,7 @@ async function fetchDataByCode(paramCode) {
     const wrappedfetchMeasurments = limiter.wrap(fetchMeasurments.bind(null, paramCode));
     const formattedStations = await Promise.all(
         stations
-        // .slice(0,2) // for testing
+        // .slice(0,5) // for testing
         .map(async (station) => {
             const detailedStation = await wrappedfetchMeasurments(station);
             return formatData(detailedStation, paramCode);
@@ -134,7 +134,7 @@ function formatData(station, paramCode) {
     const dateTime = DateTime.fromFormat(
         station.ENG_DATA_TIME,
         'yyyy-MM-dd : HH',
-        { zone: 'UTC' }
+        { zone: 'Asia/Seoul' }
     );
 
     return {
@@ -146,8 +146,8 @@ function formatData(station, paramCode) {
         },
         parameter: station.name.toLowerCase().replace('.', ''),
         date: {
-            utc: dateTime.toISO({suppressMilliseconds: true}),
-            local: dateTime.setZone('Asia/Seoul').toISO({suppressMilliseconds: true}),
+            utc: dateTime.toUTC().toISO({suppressMilliseconds: true}),
+            local: dateTime.toISO({suppressMilliseconds: true}),
         },
         value: station.measurementValue,
         unit: paramCodes[paramCode].unit,

--- a/src/deployments.js
+++ b/src/deployments.js
@@ -38,10 +38,6 @@ const deploymentsArray = [
     source: 'Sinaica Mexico'
   },
   {
-    name: 'southkorea',
-    source: 'korea-air'
-  },
-  {
   // Fill gaps in Hanoi data
     name: 'hanoi',
     source: 'hanoi-aqmn',

--- a/src/sources/kr.json
+++ b/src/sources/kr.json
@@ -10,6 +10,6 @@
         "contacts": [
             "info@openaq.org"
         ],
-        "active": false
+        "active": true
     }
 ]


### PR DESCRIPTION
Fix to correctly assign timezone for the `air-korea` adapter. Time was being incorrectly set as `UTC` from the source when the source datetimes are reported in `Asia/Seoul` timezone.

Fix to be merged after datetime correction for measurements already recorded