### PR TITLE
Fix South Africa (SAAQIS) adapter for the upgraded Envista platform

### DIFF
--- a/src/adapters/southafrica.js
+++ b/src/adapters/southafrica.js
@@ -1,109 +1,262 @@
 /**
  * This code is responsible for implementing all methods related to fetching
  * and returning data for the South African data sources.
+ *
+ * SAAQIS (South African Air Quality Information System) runs Envitech
+ * Envista Web. A platform upgrade removed the old public
+ * /ajax/getAllStationsWithoutFiltering endpoint this adapter used to scrape,
+ * which is why the source went stale in March 2024. The current portal
+ * exposes an anonymous two-step flow instead:
+ *
+ *   1. POST {url}Account/GetApiFromBackToken -> { key, timeout } - a
+ *      short-lived (30 min) key tied to the ASP.NET session cookie.
+ *   2. POST {url}api with `Authorization: <key>` (same cookie jar) and a
+ *      JSON body describing the inner Envista REST request, e.g.
+ *      { url: 'regions', Method: 'GET', ... }.
+ *
+ * The proxied Envista responses ('regions', 'stations/{id}/data/latest')
+ * have the same shapes consumed by the israel-envista adapter, so this
+ * adapter follows its structure. No credentials are required.
  */
 
 'use strict';
 
-import {
-  unifyMeasurementUnits,
-  removeUnwantedParameters,
-  unifyParameters,
-} from '../lib/utils.js';
 import log from '../lib/logger.js';
-
-import { DateTime } from 'luxon';
-import _ from 'lodash';
 import client from '../lib/requests.js';
+
+import { CookieJar } from 'tough-cookie';
+import { DateTime } from 'luxon';
+import { parallelLimit } from 'async';
+import {
+  convertUnits,
+  unifyMeasurementUnits,
+  acceptableParameters,
+} from '../lib/utils.js';
 
 export const name = 'southafrica';
 
+const TIMEZONE = 'Africa/Johannesburg';
+
 /**
- * Fetches the data for a given source and returns an appropriate objectlog
- *
- * @param {object} source A valid source object
- * @param {function} cb A callback of the form cb(err, data)
+ * Fetches data from the SAAQIS Envista web API.
+ * @param {Object} source - The source configuration object.
+ * @param {Function} cb - The callback function to handle the fetched data.
  */
-
-export async function fetchData (source, cb) {
+export async function fetchData(source, cb) {
   try {
-		// source has a redirect that goes to an html page which causes issues
-    const body = await client({ url: source.url });
+    const session = await createSession(source);
+    const regionList = await envistaGet(source, session, 'regions');
 
-    // Wrap everything in a try/catch in case something goes wrong
-    // Format the data
-    const data = formatData(body);
-    // Make sure the data is valid
-    if (data === undefined) {
-      return cb({ message: 'Failure to parse data.' });
-    }
-    cb(null, data);
+    // One flat station queue across all regions: SAAQIS times out when
+    // hit with per-region parallelism (9 regions x N stations at once).
+    const stationList = regionList.flatMap((region) =>
+      (region.stations || [])
+        .filter((station) => station.active && hasAcceptedParameters(station))
+        .map((station) => ({ station, regionName: region.name }))
+    );
+
+    const limit = 10; // concurrent station requests SAAQIS handles reliably
+
+    const results = await new Promise((resolve, reject) => {
+      parallelLimit(
+        stationList.map(({ station, regionName }) => (callback) =>
+          handleStation(source, session, regionName, station).then(
+            (measurements) => callback(null, measurements),
+            (err) => callback(err)
+          )
+        ),
+        limit,
+        (err, res) => (err ? reject(err) : resolve(res))
+      );
+    });
+
+    const flatResults = results.flat(Infinity);
+    const convertedResults = convertUnits(flatResults);
+
+    log.debug(`Example measurements: ${convertedResults.slice(0, 5)}.`);
+
+    return cb(null, { name: 'unused', measurements: convertedResults });
   } catch (err) {
-    log.error('Request error:', err); // Log the error object
-    return cb(err, { message: 'Failure to load data url.' });
+    log.error(`Error fetching data: ${err.message}`);
+    return cb({ message: 'Failure to load data url.' });
   }
 }
 
 /**
- * Given fetched data, turn it into a format our system can use.
- * @param {array} results Fetched source data and other metadata
- * @return {object} Parsed and standarized data our system can use
+ * Creates an anonymous SAAQIS API session: the token from
+ * Account/GetApiFromBackToken is only valid together with the session
+ * cookie issued alongside it, so the same cookie jar must be used for
+ * every subsequent request.
+ * @param {Object} source - The source configuration object.
+ * @returns {Promise<Object>} A promise resolving to { cookieJar, key }.
  */
+async function createSession(source) {
+  const cookieJar = new CookieJar();
+  const response = await client({
+    url: `${source.url}Account/GetApiFromBackToken`,
+    method: 'POST',
+    params: {},
+    cookieJar,
+  });
+  if (!response || !response.key) {
+    throw new Error('SAAQIS did not issue an API token');
+  }
+  return { cookieJar, key: response.key };
+}
 
-const formatData = function (data) {
-  /**
-   * Given a measurement object, convert to system appropriate times.
-   * @param {object} m A source measurement object
-   * @return {object} An object containing both UTC and local times
-   */
-  const parseDate = function (m) {
-    let date;
-    if (m.includes('/')) {
-      date = DateTime.fromFormat(m, 'yyyy/MM/dd HH:mm', {
-        zone: 'Africa/Johannesburg',
-      });
-    } else if (m.includes('T') && m.includes('+')) {
-      date = DateTime.fromISO(m, { zone: 'Africa/Johannesburg' });
+/**
+ * Performs a GET request against the Envista REST API via the SAAQIS
+ * /api proxy endpoint.
+ * @param {Object} source - The source configuration object.
+ * @param {Object} session - The session object from createSession.
+ * @param {string} path - The inner Envista path, e.g. 'regions'.
+ * @returns {Promise<*>} A promise resolving to the proxied response.
+ */
+async function envistaGet(source, session, path) {
+  return client({
+    url: `${source.url}api`,
+    method: 'POST',
+    cookieJar: session.cookieJar,
+    headers: {
+      Authorization: session.key,
+      Referer: source.url,
+    },
+    params: {
+      url: path,
+      includeEnvistaPrefix: true,
+      header: { Accept: 'application/json' },
+      Method: 'GET',
+      body: null,
+      isMaintainView: false,
+    },
+  });
+}
+
+/**
+ * Handles the processing of a single station.
+ * @param {Object} source - The source configuration object.
+ * @param {Object} session - The session object from createSession.
+ * @param {string} regionName - The name of the region.
+ * @param {Object} station - The station object.
+ * @returns {Promise} A promise that resolves to an array of measurements for the station.
+ */
+async function handleStation(source, session, regionName, station) {
+  try {
+    const data = await envistaGet(
+      source,
+      session,
+      `stations/${station.stationId}/data/latest`
+    );
+    return formatData(source, regionName, station, data);
+  } catch (err) {
+    // 204 = station currently reporting no data; routine on this network.
+    if (err.message && err.message.includes('204')) {
+      log.debug(`No current data for station ${station.name}`);
     } else {
-      return null;
+      log.error(`Error fetching station data: ${err.message}`);
     }
-    return {
-      utc: date.toUTC().toISO({ suppressMilliseconds: true }),
-      local: date.toISO({ suppressMilliseconds: true }),
-    };
+    return [];
+  }
+}
+
+/**
+ * Formats the data for a single station.
+ * @param {Object} source - The source configuration object.
+ * @param {string} regionName - The name of the region.
+ * @param {Object} station - The station object.
+ * @param {Object} data - The data object retrieved from the API.
+ * @returns {Array} An array of formatted measurements.
+ */
+function formatData(source, regionName, station, data) {
+  const base = {
+    location: station.name,
+    city: regionName,
+    coordinates: {
+      latitude: parseFloat(station.location.latitude),
+      longitude: parseFloat(station.location.longitude),
+    },
+    averagingPeriod: { unit: 'hours', value: 1 },
+    attribution: [
+      {
+        name: 'South African Air Quality Information System',
+        url: source.sourceURL,
+      },
+    ],
   };
 
-  let measurements = [];
-  _.forEach(data, function (s) {
-    const base = {
-      location: s.name,
-      city: s.city,
-      coordinates: {
-        latitude: parseFloat(s.latitude),
-        longitude: parseFloat(s.longitude),
-      },
-      attribution: [
-        {
-          name: 'South African Air Quality Information System',
-          url: 'http://saaqis.environment.gov.za',
-        },
-      ],
-      averagingPeriod: { unit: 'hours', value: 1 },
-    };
-    _.forOwn(s.monitors, function (v, key) {
-      if (v.value !== null && v.value !== '' && v.DateVal !== null) {
-        let m = _.clone(base);
-        m.parameter = v.Pollutantname;
-        m.value = parseFloat(v.value);
-        m.unit = v.unit;
-        m.date = parseDate(v.DateVal);
-        m = unifyMeasurementUnits(m);
-        m = unifyParameters(m);
-        measurements.push(m);
-      }
-    });
+  const timeWindow = DateTime.utc().minus({ hours: 6 });
+
+  const filteredData = (data.data || []).filter((datapoint) => {
+    const measurementDateTime = DateTime.fromISO(datapoint.datetime);
+    return measurementDateTime >= timeWindow;
   });
 
-  measurements = removeUnwantedParameters(measurements);
-  return { name: 'unused', measurements: measurements };
-};
+  return filteredData
+    .map((datapoint) => formatChannels(base, datapoint))
+    .flat()
+    .filter((measurement) => measurement);
+}
+
+/**
+ * Formats the channels for a single datapoint.
+ * @param {Object} base - The base measurement object.
+ * @param {Object} datapoint - The datapoint object.
+ * @returns {Array} An array of formatted measurements.
+ */
+function formatChannels(base, datapoint) {
+  const date = getDate(datapoint.datetime);
+
+  return datapoint.channels
+    .filter(
+      (channel) =>
+        channel.valid && isAcceptedParameter(channel.name)
+    )
+    .map((channel) => ({
+      ...base,
+      ...date,
+      parameter: channel.name.toLowerCase().split('.').join(''),
+      value: channel.value,
+      unit: channel.units,
+    }))
+    .map(unifyMeasurementUnits)
+    // A few stations report CO in units we cannot convert reliably
+    // (e.g. mg/Nm3, a normalized-volume unit); drop those measurements.
+    .filter((m) => ['µg/m³', 'ppm', 'ppb'].includes(m.unit));
+}
+
+/**
+ * Checks if a station has accepted parameters.
+ * @param {Object} station - The station object.
+ * @returns {boolean} True if the station has accepted parameters, false otherwise.
+ */
+function hasAcceptedParameters(station) {
+  const stationParameters = (station.monitors || []).map((monitor) =>
+    monitor.name.toLowerCase().split('.').join('')
+  );
+  return acceptableParameters.some((param) =>
+    stationParameters.includes(param)
+  );
+}
+
+/**
+ * Checks if a parameter is accepted.
+ * @param {string} parameter - The parameter to check.
+ * @returns {boolean} True if the parameter is accepted, false otherwise.
+ */
+function isAcceptedParameter(parameter) {
+  return acceptableParameters.includes(
+    parameter.toLowerCase().split('.').join('')
+  );
+}
+
+/**
+ * Gets the date object from a datetime string.
+ * @param {string} value - The datetime string.
+ * @returns {Object} An object containing the UTC and local date strings.
+ */
+function getDate(value) {
+  const dt = DateTime.fromISO(value, { zone: TIMEZONE });
+  const utc = dt.toUTC().toISO({ suppressMilliseconds: true });
+  const local = dt.toISO({ suppressMilliseconds: true });
+  return { date: { utc, local } };
+}

--- a/src/adapters/southafrica.js
+++ b/src/adapters/southafrica.js
@@ -14,9 +14,16 @@
  *      JSON body describing the inner Envista REST request, e.g.
  *      { url: 'regions', Method: 'GET', ... }.
  *
- * The proxied Envista responses ('regions', 'stations/{id}/data/latest')
- * have the same shapes consumed by the israel-envista adapter, so this
+ * The proxied Envista responses ('regions', 'regions/data/latest') have
+ * the same shapes consumed by the israel-envista adapter, so this
  * adapter follows its structure. No credentials are required.
+ *
+ * Data is fetched in a single bulk call
+ * ('regions/data/latest?unitConversion=true&regionsIds=...&timebase=60')
+ * rather than one request per station; unitConversion=true makes Envista
+ * serve gas concentrations in ppm/ppb (notably converting the one CO
+ * channel natively stored in mg/Nm3, a normalized-volume unit we could
+ * not convert reliably ourselves).
  */
 
 'use strict';
@@ -26,7 +33,6 @@ import client from '../lib/requests.js';
 
 import { CookieJar } from 'tough-cookie';
 import { DateTime } from 'luxon';
-import { parallelLimit } from 'async';
 import {
   convertUnits,
   unifyMeasurementUnits,
@@ -47,30 +53,43 @@ export async function fetchData(source, cb) {
     const session = await createSession(source);
     const regionList = await envistaGet(source, session, 'regions');
 
-    // One flat station queue across all regions: SAAQIS times out when
-    // hit with per-region parallelism (9 regions x N stations at once).
-    const stationList = regionList.flatMap((region) =>
-      (region.stations || [])
-        .filter((station) => station.active && hasAcceptedParameters(station))
-        .map((station) => ({ station, regionName: region.name }))
+    // Station metadata (name, coordinates, region) only comes from the
+    // regions listing, so index it by stationId for the bulk lookup.
+    const stationsById = new Map();
+    const regionIds = [];
+    for (const region of regionList) {
+      if (!region.stations || region.stations.length === 0) continue;
+      regionIds.push(region.regionId);
+      for (const station of region.stations) {
+        if (station.active && hasAcceptedParameters(station)) {
+          stationsById.set(station.stationId, {
+            station,
+            regionName: region.name,
+          });
+        }
+      }
+    }
+
+    // One bulk call for the latest hourly reading of every station,
+    // instead of ~200 per-station requests (which SAAQIS also times out
+    // on under parallelism). Silent stations are simply absent here.
+    const bulk = await envistaGet(
+      source,
+      session,
+      `regions/data/latest?unitConversion=true&regionsIds=${regionIds.join(
+        ','
+      )}&timebase=60`
     );
 
-    const limit = 10; // concurrent station requests SAAQIS handles reliably
+    const flatResults = (bulk || [])
+      .filter((entry) => entry.regionData && stationsById.has(entry.stationId))
+      .flatMap((entry) => {
+        const { station, regionName } = stationsById.get(entry.stationId);
+        return formatData(source, regionName, station, {
+          data: [entry.regionData],
+        });
+      });
 
-    const results = await new Promise((resolve, reject) => {
-      parallelLimit(
-        stationList.map(({ station, regionName }) => (callback) =>
-          handleStation(source, session, regionName, station).then(
-            (measurements) => callback(null, measurements),
-            (err) => callback(err)
-          )
-        ),
-        limit,
-        (err, res) => (err ? reject(err) : resolve(res))
-      );
-    });
-
-    const flatResults = results.flat(Infinity);
     const convertedResults = convertUnits(flatResults);
 
     log.debug(`Example measurements: ${convertedResults.slice(0, 5)}.`);
@@ -133,33 +152,6 @@ async function envistaGet(source, session, path) {
 }
 
 /**
- * Handles the processing of a single station.
- * @param {Object} source - The source configuration object.
- * @param {Object} session - The session object from createSession.
- * @param {string} regionName - The name of the region.
- * @param {Object} station - The station object.
- * @returns {Promise} A promise that resolves to an array of measurements for the station.
- */
-async function handleStation(source, session, regionName, station) {
-  try {
-    const data = await envistaGet(
-      source,
-      session,
-      `stations/${station.stationId}/data/latest`
-    );
-    return formatData(source, regionName, station, data);
-  } catch (err) {
-    // 204 = station currently reporting no data; routine on this network.
-    if (err.message && err.message.includes('204')) {
-      log.debug(`No current data for station ${station.name}`);
-    } else {
-      log.error(`Error fetching station data: ${err.message}`);
-    }
-    return [];
-  }
-}
-
-/**
  * Formats the data for a single station.
  * @param {Object} source - The source configuration object.
  * @param {string} regionName - The name of the region.
@@ -219,8 +211,8 @@ function formatChannels(base, datapoint) {
       unit: channel.units,
     }))
     .map(unifyMeasurementUnits)
-    // A few stations report CO in units we cannot convert reliably
-    // (e.g. mg/Nm3, a normalized-volume unit); drop those measurements.
+    // unitConversion=true plus unifyMeasurementUnits should leave only
+    // system units; guard against any residual exotic units regardless.
     .filter((m) => ['µg/m³', 'ppm', 'ppb'].includes(m.unit));
 }
 

--- a/src/sources/za.json
+++ b/src/sources/za.json
@@ -16,15 +16,16 @@
     "active": false
   },
   {
-    "url": "http://saaqis.environment.gov.za/ajax/getAllStationsWithoutFiltering",
+    "url": "https://saaqis.environment.gov.za/",
     "adapter": "southafrica",
     "name": "South Africa",
     "country": "ZA",
-    "description": "Air Quality data from South African Department Enviromental Affairs",
-    "sourceURL": "http://saaqis.environment.gov.za",
+    "description": "Air Quality data from the South African Air Quality Information System (DFFE/SAWS)",
+    "sourceURL": "https://saaqis.environment.gov.za",
+    "timezone": "Africa/Johannesburg",
     "contacts": [
         "info@openaq.org"
     ],
-    "active": false
+    "active": true
   }
 ]


### PR DESCRIPTION
## Problem

The South Africa source has been inactive since March 2024 (switched off in #1094). The cause: SAAQIS upgraded their Envitech Envista platform, and the public `/ajax/getAllStationsWithoutFiltering` endpoint the adapter scraped no longer exists (it now 302s to an error page).

The network itself is alive: 228 stations across all nine provinces (DFFE, SAWS, metros and provincial owners), with PM2.5 currently reporting at ~75 stations.

## Fix

The upgraded portal exposes an anonymous two-step flow, which this rewrite uses:

1. `POST {url}Account/GetApiFromBackToken` with an empty JSON body returns `{ key, timeout }` - a short-lived (30 min) key tied to the ASP.NET session cookie issued alongside it.
2. `POST {url}api` with `Authorization: <key>` (same cookie jar, hence `tough-cookie` as in the trinidadtobago adapter) proxies Envista REST requests: `regions`, `stations/{id}/data/latest`.

No credentials or registration are required. The proxied responses have the same shapes consumed by the israel-envista adapter, so the rewrite follows its structure.

Implementation notes:
- One flat station queue (concurrency 10) across all regions - SAAQIS times out under per-region parallelism.
- HTTP 204 means a station is currently silent, which is routine on this network; logged at debug rather than error.
- Channels are filtered on the API's own `valid` flag.
- Measurements in units that cannot be converted reliably (one station reports CO in mg/Nm3) are dropped.
- `za.json`: updated URL to https, set `active: true`, added timezone. The Richards Bay entry is untouched.

## Verification

Dry run today (`--dryrun --source 'South Africa'`):

```
566 new measurements found for "South Africa" in 31.356s
Finished with 1 successes and 0 failures in 31.615 seconds
```

566 hourly measurements from 100+ stations, including pm25 at 75 stations, no validation warnings. Sample measurement:

```json
{
  "location": "Ermelo-NAQI",
  "city": "Mpumalanga",
  "coordinates": { "latitude": -26.493348, "longitude": 29.968054 },
  "averagingPeriod": { "unit": "hours", "value": 1 },
  "date": { "utc": "2026-07-12T09:02:00Z", "local": "2026-07-12T11:02:00+02:00" },
  "parameter": "pm25",
  "value": 6.862,
  "unit": "µg/m³"
}
```

## Context

We run habistats.info, an environmental comfort index that uses OpenAQ ground monitors for air quality scoring, and noticed South Africa's absence while investigating data for Pretoria. Happy to adjust anything to fit your conventions.