### PR TITLE
ignore busted https certs on air4thai 

### DIFF
--- a/src/adapters/air4thai.js
+++ b/src/adapters/air4thai.js
@@ -21,7 +21,8 @@ export const name = 'air4thai';
  */
 
 export function fetchData (source, cb) {
-  client({ url: source.url })
+  // air4thai's cert is broken, so don't require it match. 
+  client({ url: source.url, https: { rejectUnauthorized: false } })
     .then((data) => {
 
       const formattedData = formatData(data);

--- a/src/sources/th.json
+++ b/src/sources/th.json
@@ -14,7 +14,7 @@
         "active": false
     },
     {
-        "url": "http://air4thai.pcd.go.th/forappV2/getAQI_JSON.php",
+        "url": "https://air4thai.pcd.go.th/forappV2/getAQI_JSON.php",
         "adapter": "air4thai",
         "name": "Air4Thai",
         "city": "",


### PR DESCRIPTION
This seemed to fix things in not-quite-realistic local tests.

Also sets the url to https. It currently is set to http and redirects to https so this just reflects that. 